### PR TITLE
dedupe context rules better

### DIFF
--- a/apps/os/app/app.css
+++ b/apps/os/app/app.css
@@ -120,14 +120,11 @@
 }
 
 /* CodeMirror search panel sticky positioning */
-.cm-search.cm-panel {
-  position: sticky !important;
-  top: 0 !important;
-  z-index: 10 !important;
-  background: hsl(var(--background)) !important;
-  border-bottom: 1px solid hsl(var(--border)) !important;
-  margin: 0 !important;
-  padding: 8px !important;
+.cm-SerializedObjectCodeBlock .cm-search.cm-panel {
+  position: fixed;
+  top: 0;
+  z-index: 10;
+  background: grey;
 }
 
 /* Ensure the CodeMirror editor container allows for sticky positioning */

--- a/apps/os/app/app.css
+++ b/apps/os/app/app.css
@@ -118,3 +118,23 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* CodeMirror search panel sticky positioning */
+.cm-search.cm-panel {
+  position: sticky !important;
+  top: 0 !important;
+  z-index: 10 !important;
+  background: hsl(var(--background)) !important;
+  border-bottom: 1px solid hsl(var(--border)) !important;
+  margin: 0 !important;
+  padding: 8px !important;
+}
+
+/* Ensure the CodeMirror editor container allows for sticky positioning */
+.cm-editor {
+  position: relative !important;
+}
+
+.cm-scroller {
+  overflow: auto !important;
+}

--- a/apps/os/app/components/serialized-object-code-block.tsx
+++ b/apps/os/app/components/serialized-object-code-block.tsx
@@ -140,14 +140,15 @@ export function SerializedObjectCodeBlock({
   const extensions: CodeMirrorProps["extensions"] = [
     basicSetup,
     lang(),
-    search(),
+    search({ top: true }),
     keymap.of(searchKeymap),
     EditorView.editable.of(false), // This is enough for readonly
+    EditorView.contentAttributes.of({ tabindex: "0" }), // Make focusable for keyboard shortcuts
   ];
 
   return (
     <div className="relative">
-      <div className={clsx("rounded overflow-hidden", className)}>
+      <div className={clsx("rounded overflow-hidden overflow-y-auto", className)}>
         <CodeMirror value={code} extensions={extensions} />
       </div>
 

--- a/apps/os/app/components/serialized-object-code-block.tsx
+++ b/apps/os/app/components/serialized-object-code-block.tsx
@@ -143,12 +143,18 @@ export function SerializedObjectCodeBlock({
     search({ top: true }),
     keymap.of(searchKeymap),
     EditorView.editable.of(false), // This is enough for readonly
-    EditorView.contentAttributes.of({ tabindex: "0" }), // Make focusable for keyboard shortcuts
+    EditorView.contentAttributes.of({ tabindex: "0" }), // Make focusable for keyboard shortcutss
   ];
 
   return (
     <div className="relative">
-      <div className={clsx("rounded overflow-hidden overflow-y-auto", className)}>
+      <div
+        className={clsx(
+          "cm-SerializedObjectCodeBlock",
+          "rounded overflow-hidden overflow-y-auto",
+          className,
+        )}
+      >
         <CodeMirror value={code} extensions={extensions} />
       </div>
 

--- a/apps/os/backend/agent/agent-core.ts
+++ b/apps/os/backend/agent/agent-core.ts
@@ -309,11 +309,9 @@ export class AgentCore<
     });
     // Include prompts from enabled context rules as ephemeral prompt fragments so they are rendered
     // into the LLM instructions for this request. These are ephemeral and recomputed per request.
-    for (const rule of enabledContextRules) {
-      if (rule.prompt) {
-        next.ephemeralPromptFragments[rule.key] = rule.prompt;
-      }
-    }
+    next.ephemeralPromptFragments = Object.fromEntries(
+      enabledContextRules.flatMap((r) => (r.prompt ? [[r.key, r.prompt] as const] : [])),
+    );
     const updatedContextRulesTools = enabledContextRules.flatMap((rule) => rule.tools || []);
     next.groupedRuntimeTools = {
       ...next.groupedRuntimeTools,

--- a/apps/os/backend/agent/iterate-agent.ts
+++ b/apps/os/backend/agent/iterate-agent.ts
@@ -41,7 +41,7 @@ import { renderPromptFragment } from "./prompt-fragments.ts";
 import type { ToolSpec } from "./tool-schemas.ts";
 import { toolSpecsToImplementations } from "./tool-spec-to-runtime-tool.ts";
 import { defaultContextRules } from "./default-context-rules.ts";
-import type { ContextRule } from "./context-schemas.ts";
+import { ContextRule } from "./context-schemas.ts";
 import type { MCPServer } from "./tool-schemas.ts";
 
 // Commented imports (preserved for reference)
@@ -591,7 +591,7 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
   }
 
   async getAddContextRulesEvent(): Promise<AddContextRulesEvent> {
-    const rules = await this.getContextRules();
+    const rules = ContextRule.array().parse(await this.getContextRules());
     return {
       type: "CORE:ADD_CONTEXT_RULES",
       data: { rules },

--- a/apps/os/backend/agent/tool-spec-to-runtime-tool.ts
+++ b/apps/os/backend/agent/tool-spec-to-runtime-tool.ts
@@ -65,7 +65,7 @@ function fiddleWithJsonSchema(
   let jsonSchema = structuredClone(originalJsonSchema); // deep since we're going to modify deeply-nested properties
   jsonSchema = subtractObjectPropsFromJSONSchema(jsonSchema, options?.passThroughArgs || {});
 
-  // Save the original schema with correct required arrays before makeJSONSchemaOpenAICompatible modifies them
+  // Save the original schema with correct required arrays before makeJSONSchemaOpenAICompatible modifies them.
   const schemaBeforeOpenAIModification = options?.hideOptionalInputs
     ? structuredClone(jsonSchema)
     : null;

--- a/apps/os/backend/agent/tool-spec-to-runtime-tool.ts
+++ b/apps/os/backend/agent/tool-spec-to-runtime-tool.ts
@@ -62,12 +62,12 @@ function fiddleWithJsonSchema(
   /** Options for the hacks - these match the form of an AgentDurableObjectToolSpec `passThroughArgs` and `hideOptionalInputs` props */
   options: Pick<AgentDurableObjectToolSpec, "passThroughArgs" | "hideOptionalInputs">,
 ) {
-  let jsonSchema = originalJsonSchema;
+  let jsonSchema = structuredClone(originalJsonSchema); // deep since we're going to modify deeply-nested properties
   jsonSchema = subtractObjectPropsFromJSONSchema(jsonSchema, options?.passThroughArgs || {});
 
   // Save the original schema with correct required arrays before makeJSONSchemaOpenAICompatible modifies them
   const schemaBeforeOpenAIModification = options?.hideOptionalInputs
-    ? JSON.parse(JSON.stringify(jsonSchema))
+    ? structuredClone(jsonSchema)
     : null;
 
   // This is a function Andy has written a while back


### PR DESCRIPTION
1. parse em to apply defaults
2. structuredClone before modify so originals don't get edited
3. add in some search bar fixes for codemirror, whoops