### PR TITLE
feat: Add untils to interact with github app tokens

### DIFF
--- a/apps/os/sdk/cli/cli-db.ts
+++ b/apps/os/sdk/cli/cli-db.ts
@@ -1,0 +1,22 @@
+/**
+ * Basically the same as the backend/db/client.ts file, but without cloudflare specific stuff.
+ */
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import * as schema from "../../backend/db/schema.ts";
+
+if (!process.env.DRIZZLE_RW_POSTGRES_CONNECTION_STRING) {
+  throw new Error("DRIZZLE_RW_POSTGRES_CONNECTION_STRING is not set");
+}
+
+const pg = postgres(process.env.DRIZZLE_RW_POSTGRES_CONNECTION_STRING, {
+  max: 5,
+  // If you are not using array types in your Postgres schema, disable `fetch_types` to avoid an additional round-trip (unnecessary latency)
+  fetch_types: false,
+});
+
+export const db = drizzle(pg, { schema, casing: "snake_case" });
+
+export type DB = typeof db;
+
+export * as schema from "../../backend/db/schema.ts";

--- a/apps/os/sdk/cli/commands/checkout-estate.ts
+++ b/apps/os/sdk/cli/commands/checkout-estate.ts
@@ -3,31 +3,70 @@ import * as path from "path";
 import * as fs from "fs/promises";
 import { z } from "zod";
 import { x as exec } from "tinyexec";
-import { EstateSpecifierFromString } from "../estate-specifier.ts";
 import { t } from "../config.ts";
+import { getRepoAccessToken } from "../github-utils.ts";
 
 export const checkoutEstateCommand = t.procedure
   .input(
     z.object({
-      estate: EstateSpecifierFromString.meta({ positional: true, alias: "e" }),
-      path: z.string().optional(),
-      rmrf: z.boolean().optional(),
+      estateId: z.string(),
+      path: z.string().optional().default(tmpdir()),
+      rmrf: z.boolean().default(false),
     }),
   )
   .mutation(async ({ input }) => {
-    const repoPath =
-      input.path ||
-      path.join(
-        tmpdir(),
-        `iterate/${input.estate.owner}/${input.estate.repo}/${Date.now()}/${input.estate.repo}`,
-      );
+    const repoPath = input.path;
+
     if (input.rmrf) {
       await fs.rm(repoPath, { recursive: true, force: true });
     }
+
     await fs.mkdir(path.dirname(repoPath), { recursive: true });
-    const cloneResult = await exec("git", ["clone", input.estate.cloneUrl, repoPath]);
+    const {
+      token,
+      repoId,
+      repoRef,
+      repoPath: estateRepoPath,
+    } = await getRepoAccessToken(input.estateId);
+
+    if (!repoId) {
+      throw new Error(`No repo is linked to estate ${input.estateId}`);
+    }
+
+    const repoNameRes = await fetch(`https://api.github.com/repositories/${repoId}`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "User-Agent": "Iterate OS",
+      },
+    });
+
+    if (!repoNameRes.ok) {
+      throw new Error(`Failed to fetch repository name: ${repoNameRes.statusText}`);
+    }
+    const repoNameData = (await repoNameRes.json()) as { full_name: string };
+    const repoName = repoNameData.full_name;
+
+    console.log(`Cloning repository ${repoName} to ${repoPath}`);
+    const fullCloneUrl = `https://x-access-token:${token}@github.com/${repoName}`;
+
+    const cloneResult = await exec("git", ["clone", fullCloneUrl, repoPath]);
     if (cloneResult.exitCode !== 0) {
       throw new Error(`Failed to clone repository: ${cloneResult.stderr}`);
     }
-    return path.join(repoPath, input.estate.directory || ".");
+
+    if (repoRef) {
+      // Checkout the repository to the ref
+      exec("git", ["checkout", repoRef], {
+        nodeOptions: {
+          cwd: repoPath,
+        },
+      });
+    }
+
+    return path.join(repoPath, estateRepoPath || ".");
   });
+
+export const estate = t.router({
+  checkout: checkoutEstateCommand,
+});

--- a/apps/os/sdk/cli/commands/gh-commands.ts
+++ b/apps/os/sdk/cli/commands/gh-commands.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import { t } from "../config.ts";
+import { getRepoAccessToken } from "../github-utils.ts";
+
+export const ghPrintSetup = t.procedure
+  .input(
+    z.object({
+      estateId: z.string(),
+    }),
+  )
+  .mutation(async ({ input }) => {
+    const { estateId } = input;
+    const { token } = await getRepoAccessToken(estateId);
+    console.log(`Use this token to authenticate with the token scoped to this estate`);
+    console.log(`export GH_TOKEN=${token}`);
+  });
+
+export const gh = t.router({
+  printSetup: ghPrintSetup,
+});

--- a/apps/os/sdk/cli/github-utils.ts
+++ b/apps/os/sdk/cli/github-utils.ts
@@ -1,0 +1,68 @@
+import { createPrivateKey } from "crypto";
+import { eq, and } from "drizzle-orm";
+import { SignJWT } from "jose";
+import { db, schema } from "./cli-db.ts";
+
+// Same as the backend/integrations/github/github-utils.ts file
+async function generateGithubJWT() {
+  const alg = "RS256";
+  const now = Math.floor(Date.now() / 1000);
+  if (!process.env.GITHUB_APP_PRIVATE_KEY || !process.env.GITHUB_APP_CLIENT_ID) {
+    throw new Error("GITHUB_APP_PRIVATE_KEY or GITHUB_APP_CLIENT_ID is not set");
+  }
+
+  const key = createPrivateKey({
+    key: process.env.GITHUB_APP_PRIVATE_KEY,
+    format: "pem",
+  });
+
+  return await new SignJWT({})
+    .setProtectedHeader({ alg, typ: "JWT" })
+    .setIssuedAt(now - 60)
+    .setExpirationTime(now + 9 * 60)
+    .setIssuer(process.env.GITHUB_APP_CLIENT_ID)
+    .sign(key);
+}
+
+export async function getRepoAccessToken(estateId: string) {
+  const [result] = await db
+    .select({
+      estateId: schema.estate.id,
+      accountId: schema.account.accountId,
+      repoId: schema.estate.connectedRepoId,
+      repoRef: schema.estate.connectedRepoRef,
+      repoPath: schema.estate.connectedRepoPath,
+    })
+    .from(schema.estate)
+    .innerJoin(
+      schema.estateAccountsPermissions,
+      eq(schema.estate.id, schema.estateAccountsPermissions.estateId),
+    )
+    .innerJoin(schema.account, eq(schema.estateAccountsPermissions.accountId, schema.account.id))
+    .where(and(eq(schema.estate.id, estateId), eq(schema.account.providerId, "github-app")))
+    .limit(1);
+
+  if (!result) {
+    throw new Error(`GitHub account not found for estate ${estateId}`);
+  }
+
+  const installationId = result.accountId;
+  const githubJWT = await generateGithubJWT();
+
+  const tokenRes = await fetch(
+    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${githubJWT}`,
+        "User-Agent": "Iterate OS",
+      },
+    },
+  );
+
+  if (!tokenRes.ok) {
+    throw new Error(`Failed to fetch installation token: ${tokenRes.statusText}`);
+  }
+  const { token } = (await tokenRes.json()) as { token: string };
+  return { token, repoId: result.repoId, repoRef: result.repoRef, repoPath: result.repoPath };
+}

--- a/apps/os/sdk/cli/index.ts
+++ b/apps/os/sdk/cli/index.ts
@@ -1,10 +1,12 @@
 import { createCli } from "trpc-cli";
 import * as prompts from "@clack/prompts";
 import { t } from "./config.ts";
-import { checkoutEstateCommand } from "./commands/checkout-estate.ts";
+import { estate } from "./commands/checkout-estate.ts";
+import { gh } from "./commands/gh-commands.ts";
 
 const router = t.router({
-  estate: { checkout: checkoutEstateCommand },
+  estate,
+  gh,
 });
 
 const cli = createCli({ router });


### PR DESCRIPTION
TLDR  
\- Cloning can be done for private repos with installation tokens  
\- Util to print out the temp access token, so we can use them in local `gh`​ and later pass them into containers