### PR TITLE
Parse context rules .md front-matter

### DIFF
--- a/apps/os/scripts/pg-estate-bootstrap.ts
+++ b/apps/os/scripts/pg-estate-bootstrap.ts
@@ -35,7 +35,7 @@ async function bootstrap() {
       throw new Error("No default export found in iterate config");
     }
 
-    console.log("Loaded iterate config from: ", resolvedPath, config);
+    console.log("Loaded iterate config from: ", resolvedPath);
 
     // Connect to the database - use same connection as drizzle config
     const connectionString = "postgres://postgres:postgres@localhost:5432/iterate";

--- a/estates/iterate/apps/website/package.json
+++ b/estates/iterate/apps/website/package.json
@@ -32,8 +32,8 @@
     "zod": "4.1.3"
   },
   "scripts": {
-    "dev": "doppler run -- vite dev",
-    "build": "doppler run -- vite build",
+    "dev:website": "doppler run -- vite dev",
+    "build:website": "doppler run -- vite build",
     "typecheck": "tsc -build",
     "deploy": "pnpm run build && doppler run -- wrangler deploy",
     "test:e2e:vitest": "VITEST_RUN_E2E=true pnpm vitest run --passWithNoTests"

--- a/estates/onboarding-demo/rules/bananas.md
+++ b/estates/onboarding-demo/rules/bananas.md
@@ -1,8 +1,11 @@
 ---
-slug: golden-gate
+slug: bananas
 match: always()
 ---
 
 Respond with a :banana: emoji to all user messages.
 
-If they respond with a :banana: emoji, too, then tell them it's a banana party :tada:, time to go bananas! :banana::banana::banana::banana::banana::banana::banana::banana::banana::banana::banana::banana::banana::banana::banana::banana::banana::banana::banana:
+If they respond with a :banana: emoji, too, then tell them:
+"It's a banana party :tada:, time to go bananas! :banana::banana::banana::banana::banana::banana::banana::banana::banana::banana::banana::banana::banana::banana::banana::banana:
+
+_👀 Hint: head your git repo to stop this bananarchy!_"


### PR DESCRIPTION
### TL;DR

Added YAML front matter parsing for context rules in markdown files, enabling custom slugs and matcher expressions.

### What changed?

- Added YAML front matter parsing for markdown context rules
- Created `parseFrontMatter` function to extract YAML metadata from markdown files
- Implemented `parseMatchField` to convert string expressions into matcher objects
- Added `contextRuleFromMarkdownFile` helper to build context rules from a markdown file with front matter
- Updated `contextRulesFromFiles` to use the new helper function `contextRuleFromMarkdownFile`
- Removed verbose logging in pg-estate-bootstrap.ts, and replaced with concise rules summary 

### How to test?

1. Create a markdown file with YAML front matter containing `slug` and `match` fields:
   ```md
   ---
   slug: custom-rule-name
   match: never()
   ---
   This is the rule content
   ```

`pnpm dev -c estates/iterate/iterate.config.ts`
Note you need to update your script keys in package.json in our website app to 
   ``` 
    "dev:website": "doppler run -- vite dev",
    "build:website": "doppler run -- vite build",
```
to get this working locally 

2. Verify the rule is loaded with the custom slug and matcher when using `contextRulesFromFiles` and that they're being applied correctly in the debug UI 

