### PR TITLE
Adjust Slack bot scopes and footer copy

### DIFF
--- a/apps/os/backend/auth/integrations.ts
+++ b/apps/os/backend/auth/integrations.ts
@@ -18,12 +18,12 @@ import { syncSlackUsersInBackground } from "../integrations/slack/slack.ts";
 import { MCPOAuthState, SlackBotOAuthState } from "./oauth-state-schemas.ts";
 
 export const SLACK_BOT_SCOPES = [
+  "app_mentions:read",
   "channels:history",
   "channels:join",
   "channels:read",
   "chat:write",
   "chat:write.public",
-  "commands",
   "files:read",
   "files:write",
   "groups:history",
@@ -31,11 +31,8 @@ export const SLACK_BOT_SCOPES = [
   "im:history",
   "im:read",
   "im:write",
-  "im:write.topic",
   "mpim:history",
   "mpim:read",
-  "mpim:write",
-  "mpim:write.topic",
   "reactions:read",
   "reactions:write",
   "users.profile:read",

--- a/estates/iterate/apps/website/backend/components/SiteFooter.tsx
+++ b/estates/iterate/apps/website/backend/components/SiteFooter.tsx
@@ -34,7 +34,7 @@ export default function SiteFooter() {
               Disclaimer: This app uses generative AI to assist with operational tasks. AI-generated
               responses may contain inaccuracies or outdated information. All critical decisions
               should be validated by a human expert. Note: Your workspace needs to be on a paid
-              slack plan in order to interact with @iterate via Slack's Agent and Assistant view,
+              Slack plan in order to interact with @iterate via Slack's Agent and Assistant view,
               however users on a free plan can still interact with the bot as they would with any
               other user.
             </p>


### PR DESCRIPTION
## Summary
- add the `app_mentions:read` scope and remove unused bot scopes in the Slack integration manifest
- capitalise “Slack” in the website footer disclaimer copy

Needed for slack marketplace approval 


------
https://chatgpt.com/codex/tasks/task_b_68d414ca8ae88330bef36507084ce681