### PR TITLE
Fix: Call syncSlackUsersInBackground when linking Slack on the integrations page

### DIFF
--- a/apps/os/backend/auth/integrations.ts
+++ b/apps/os/backend/auth/integrations.ts
@@ -458,6 +458,7 @@ export const integrationsPlugin = () =>
               return ctx.json({ error: "Can't find the existing user to link to" });
             }
             user = linkedUser.user;
+            waitUntil(syncSlackUsersInBackground(db, tokens.access_token));
           }
 
           if (!user) {


### PR DESCRIPTION
Fixes [ITE-3003: Debug "Estate not found" message in MCP callback](https://linear.app/iterate-com/issue/ITE-3003/debug-estate-not-found-message-in-mcp-callback)