### PR TITLE
Feature: create SlackAgent for thread that mentions bot before the bot joined the channel

### DIFF
--- a/apps/os/backend/agent/mcp/mcp-oauth-provider.ts
+++ b/apps/os/backend/agent/mcp/mcp-oauth-provider.ts
@@ -32,6 +32,7 @@ import { DynamicClientInfo } from "../../auth/oauth-state-schemas.ts";
  * Then when it requires to get tokens(), it will get them from the account table.
  * Congrats, we successfully connected to the MCP server.
  */
+
 export class MCPOAuthProvider implements AgentsOAuthProvider {
   clientId: string | undefined;
   serverId: string | undefined;

--- a/apps/os/backend/agent/slack-agent-utils.ts
+++ b/apps/os/backend/agent/slack-agent-utils.ts
@@ -12,7 +12,7 @@ export function getMentionedExternalUserIds(body: string) {
 }
 
 export function isBotMentionedInMessage(
-  slackEvent: { user?: string; text?: string; type: string },
+  slackEvent: { user?: string; text?: string; type?: string },
   botUserId: string,
 ): boolean {
   // Skip messages from the bot itself - they shouldn't be treated as mentions

--- a/apps/os/backend/integrations/slack/slack.ts
+++ b/apps/os/backend/integrations/slack/slack.ts
@@ -352,12 +352,7 @@ async function handleBotChannelJoin(params: {
       continue;
     }
 
-    const hasBotMention = threadHistory.messages.some(
-      (m) =>
-        m.type === "message" &&
-        m.type &&
-        isBotMentionedInMessage(m as { user?: string; text?: string; type: string }, botUserId),
-    );
+    const hasBotMention = threadHistory.messages.some((m) => isBotMentionedInMessage(m, botUserId));
 
     if (!hasBotMention) continue;
 
@@ -402,12 +397,7 @@ async function handleBotChannelJoin(params: {
 
     const mentionMessage = [...threadHistory.messages]
       .reverse()
-      .find(
-        (m) =>
-          m.type === "message" &&
-          m.type &&
-          isBotMentionedInMessage(m as { user?: string; text?: string; type: string }, botUserId),
-      );
+      .find((m) => isBotMentionedInMessage(m, botUserId));
 
     if (mentionMessage?.ts) {
       try {

--- a/apps/os/backend/integrations/slack/slack.ts
+++ b/apps/os/backend/integrations/slack/slack.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { and, eq } from "drizzle-orm";
 import { WebClient, type UsersListResponse } from "@slack/web-api";
 import { waitUntil } from "cloudflare:workers";
+import * as R from "remeda";
 import { type CloudflareEnv } from "../../../env.ts";
 import type { SlackWebhookPayload } from "../../agent/slack.types.ts";
 import { getDb, type DB } from "../../db/client.ts";
@@ -17,6 +18,7 @@ import {
 import { slackWebhookEvent } from "../../db/schema.ts";
 import { getSlackAccessTokenForEstate } from "../../auth/token-utils.ts";
 import { shouldIncludeEventInConversation } from "../../agent/slack-agent-utils.ts";
+import type { AgentCoreEventInput } from "../../agent/agent-core.ts";
 
 export const slackApp = new Hono<{ Bindings: CloudflareEnv }>();
 
@@ -92,6 +94,26 @@ slackApp.post("/webhook", async (c) => {
     return c.text("ok");
   }
 
+  if (
+    body.event?.type === "message" &&
+    "subtype" in body.event &&
+    body.event.subtype === "channel_join"
+  ) {
+    const joinedUserId = body.event.user;
+    const botUserId = extractBotUserIdFromAuthorizations(body);
+
+    if (joinedUserId === botUserId) {
+      waitUntil(
+        handleBotChannelJoin({
+          db,
+          estateId,
+          channelId: body.event.channel,
+          botUserId,
+        }),
+      );
+    }
+  }
+
   waitUntil(
     // deterministically react to the webhook as early as possible (eyes emoji)
     getSlackAccessTokenForEstate(db, estateId).then(async (slackToken) => {
@@ -164,205 +186,6 @@ slackApp.post("/webhook", async (c) => {
 
   return c.text("ok");
 });
-
-// async onEventPublished(event: DispatchedEvent) {
-//   switch (event.event) {
-//     case "SYSTEM:APP_INSTALLED": {
-//       // Find the general channel
-//       const channelsResult = await serverTrpc.platform.integrations.slack.listChannels.query({
-//         types: "public_channel",
-//         exclude_archived: true,
-//       });
-
-//       if (!channelsResult.success || !channelsResult.channels) {
-//         console.error("[Platform] Could not list channels for app_installed event");
-//         return;
-//       }
-
-//       const generalChannel = channelsResult.channels.find((channel) => channel.is_general);
-//       const targetChannel = generalChannel || channelsResult.channels[0];
-
-//       if (!targetChannel) {
-//         console.error("[Platform] Could not find any suitable channel for app_installed event");
-//         return;
-//       }
-
-//       if (!generalChannel) {
-//         console.warn(
-//           `[Platform] #general channel not found, using fallback channel: ${targetChannel.name}`,
-//         );
-//       }
-
-//       const { threadTs } =
-//         await serverTrpc.platform.integrations.slack.startThreadWithAgent.mutate({
-//           channel: targetChannel.id,
-//           blocks: INITIAL_ONBOARDING_BLOCKS,
-
-//           eventsToAdd: [
-//             {
-//               type: "CORE:LLM_INPUT_ITEM",
-//               data: {
-//                 type: "message",
-//                 role: "developer",
-//                 content: [
-//                   {
-//                     type: "input_text",
-//                     text: ONBOARDING_PROMPT,
-//                   },
-//                 ],
-//               },
-//               triggerLLMRequest: false,
-//             },
-//           ],
-//         });
-
-//       if (!threadTs) {
-//         console.error("[Platform] Could not start thread for app_installed event");
-//         return;
-//       }
-
-//       await serverTrpc.platform.integrations.slack.sendSlackMessage.mutate({
-//         channel: targetChannel.id,
-//         threadTs,
-//         text: "should not be here",
-//         blocks: SECONDARY_ONBOARDING_BLOCKS,
-//       });
-
-//       const slackAgent = await getPersistedAgentByName(
-//         this.env.SLACK_AGENT,
-//         `SlackAgent ${threadTs}`,
-//         "SlackAgent",
-//         {
-//           db,
-//           table: durableObjectInstances,
-//           reason: "App installed",
-//         },
-//       );
-
-//       await slackAgent.storeModalDefinitions(MODAL_DEFINITIONS);
-
-//       return;
-//     }
-//   }
-
-//   switch (event.event) {
-//     case "SLACK:WEBHOOK_EVENT_RECEIVED":
-//       break;
-//     default:
-//       return;
-//   }
-
-//   let slackAgentInstanceName: string | null = null;
-//   switch (event.event) {
-//     case "SLACK:WEBHOOK_EVENT_RECEIVED": {
-//       const eventData = event.data as any;
-//       const slackEvent = eventData?.event as SlackEvent;
-//       if (slackEvent.type === "assistant_thread_started") {
-//         const channelId = slackEvent.assistant_thread.channel_id;
-//         const threadTs = slackEvent.assistant_thread.thread_ts;
-//         await serverTrpc.platform.integrations.slack.setSuggestedPrompts.mutate({
-//           channel_id: channelId,
-//           thread_ts: threadTs,
-//           prompts: getRandomPromptSet().prompts,
-//         });
-//       }
-
-//       // Handle channel_joined events - check recent messages for bot mentions
-//       if (
-//         slackEvent.type === "message" &&
-//         "subtype" in slackEvent &&
-//         slackEvent.subtype === "channel_join"
-//       ) {
-//         const channelId = slackEvent.channel;
-//         const botUserId = extractBotUserIdFromAuthorizations(eventData);
-
-//         if (botUserId && channelId) {
-//           await handleChannelJoinedEvent({ channelId, botUserId });
-//         }
-//       }
-//       await storeSlackWebhookEvent({ slackEvent });
-//       slackAgentInstanceName = await getAgentInstanceNamesForSlackWebhook(slackEvent);
-//       if (slackEvent.type === "app_home_opened") {
-//         await handleAppHomeOpened(slackEvent.user);
-//       }
-//       break;
-//     }
-//   }
-
-//   if (!slackAgentInstanceName) {
-//     return;
-//   }
-
-//   const agentExists = await checkPersistedAgentWithNameExists(
-//     slackAgentInstanceName,
-//     "SlackAgent",
-//     {
-//       db,
-//       table: durableObjectInstances,
-//     },
-//   );
-
-//   if (!agentExists) {
-//     switch (event.event) {
-//       case "SLACK:WEBHOOK_EVENT_RECEIVED": {
-//         const eventData = event.data as any;
-//         const slackEvent = eventData?.event as SlackEvent;
-//         const botUserId = extractBotUserIdFromAuthorizations(eventData);
-//         const isBotMentioned =
-//           botUserId && slackEvent.type === "message"
-//             ? isBotMentionedInMessage(slackEvent, botUserId)
-//             : false;
-//         const isDM = "channel_type" in slackEvent && slackEvent.channel_type === "im";
-
-//         if (!isBotMentioned && !isDM) {
-//           return;
-//         }
-//         break;
-//       }
-//     }
-//   }
-
-//   const slackAgent = await getPersistedAgentByName(
-//     this.env.SLACK_AGENT,
-//     slackAgentInstanceName,
-//     "SlackAgent",
-//     {
-//       db,
-//       table: durableObjectInstances,
-//       reason: `Event ${event.event} received`,
-//     },
-//   );
-
-//   // inject new braintrust span
-//   /*
-//   if (!agentExists) {
-//     const prefix = env.STAGE__PR_ID
-//       ? `pr-${env.STAGE__PR_ID}`
-//       : env.ITERATE_USER
-//         ? `local-${env.ITERATE_USER}`
-//         : `estate-${ESTATE_MANIFEST.estateName}`;
-//     const braintrustLogger = getBraintrustLogger({
-//       braintrustKey: this.env.BRAINTRUST_API_KEY ?? "",
-//       projectName: `${prefix}-platform`
-//     });
-//     const parentSpan = braintrustLogger.startSpan({
-//       name: slackAgentInstanceName,
-//       type: "task",
-//       startTime: Date.now() / 1000
-//     });
-//     parentSpan.end();
-//     await parentSpan.flush();
-//     const exportedId = await parentSpan.export();
-//     await slackAgent.setBraintrustParentSpanExportedId(exportedId);
-//   }
-//     */
-
-//   switch (event.event) {
-//     case "SLACK:WEBHOOK_EVENT_RECEIVED":
-//       await slackAgent.onSlackWebhookEventReceived(event.data as any);
-//       break;
-//   }
-// }
 
 export function getRoutingKey({ estateId, threadTs }: { estateId: string; threadTs: string }) {
   const suffix = `slack-${estateId}`;
@@ -484,6 +307,119 @@ export async function syncSlackUsersInBackground(db: DB, botToken: string) {
         await saveSlackUserMapping(db, member);
       }),
     );
+  }
+}
+
+async function handleBotChannelJoin(params: {
+  db: DB;
+  estateId: string;
+  channelId: string;
+  botUserId: string;
+}) {
+  const { db, estateId, channelId, botUserId } = params;
+
+  const slackToken = await getSlackAccessTokenForEstate(db, estateId);
+  if (!slackToken) {
+    console.error("No Slack token available for channel join handling");
+    return;
+  }
+
+  const slackAPI = new WebClient(slackToken);
+
+  const history = await slackAPI.conversations.history({
+    channel: channelId,
+    limit: 5,
+  });
+
+  if (!history.ok || !history.messages) {
+    console.error("Failed to fetch channel history");
+    return;
+  }
+
+  const validMessages = history.messages.filter((m) => m.ts);
+  const threadsByTs = R.groupBy(validMessages, (m) => m.thread_ts || m.ts!);
+
+  for (const [threadTs] of Object.entries(threadsByTs)) {
+    const threadHistory = await slackAPI.conversations.replies({
+      channel: channelId,
+      ts: threadTs,
+      inclusive: true,
+      limit: 100,
+    });
+
+    if (!threadHistory.ok || !threadHistory.messages) {
+      console.error(`Failed to fetch thread history for ${threadTs}`);
+      continue;
+    }
+
+    const hasBotMention = threadHistory.messages.some(
+      (m) =>
+        m.type === "message" &&
+        m.type &&
+        isBotMentionedInMessage(m as { user?: string; text?: string; type: string }, botUserId),
+    );
+
+    if (!hasBotMention) continue;
+
+    const routingKey = getRoutingKey({ estateId, threadTs });
+
+    const agentStub = await SlackAgent.getOrCreateStubByRoute({
+      db,
+      estateId,
+      route: routingKey,
+      reason: "Bot joined channel with existing mention",
+    });
+
+    const threadContext = threadHistory.messages
+      .filter((msg) => msg.user && msg.text && msg.ts && msg.type)
+      .sort((a, b) => parseFloat(a.ts!) - parseFloat(b.ts!))
+      .map((msg) => ({
+        user: msg.user,
+        text: msg.text,
+        ts: msg.ts,
+        type: msg.type,
+        timestamp: new Date(parseFloat(msg.ts!) * 1000).toISOString(),
+      }));
+
+    const contextEvents: AgentCoreEventInput[] = [
+      {
+        type: "CORE:LLM_INPUT_ITEM",
+        data: {
+          type: "message",
+          role: "developer",
+          content: [
+            {
+              type: "input_text",
+              text: `The bot was just added to this Slack channel and is joining an existing thread where it was mentioned. Here is the thread history:\n\n${JSON.stringify(threadContext, null, 2)}\n\nThe bot should acknowledge it's joining an existing conversation and respond helpfully to any questions or requests in the thread above.`,
+            },
+          ],
+        },
+        triggerLLMRequest: true,
+      },
+    ];
+
+    await agentStub.addEvents(contextEvents);
+
+    const mentionMessage = [...threadHistory.messages]
+      .reverse()
+      .find(
+        (m) =>
+          m.type === "message" &&
+          m.type &&
+          isBotMentionedInMessage(m as { user?: string; text?: string; type: string }, botUserId),
+      );
+
+    if (mentionMessage?.ts) {
+      try {
+        await slackAPI.reactions.add({
+          channel: channelId,
+          timestamp: mentionMessage.ts,
+          name: "eyes",
+        });
+      } catch (error) {
+        console.error("[SlackAgent] Failed to add reaction:", error);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Fixes [ITE-3001: Join threads after bot is added to the channel](https://linear.app/iterate-com/issue/ITE-3001/join-threads-after-bot-is-added-to-the-channel)