### PR TITLE
user impersonation

### DIFF
--- a/apps/os/app/components/auth-components.tsx
+++ b/apps/os/app/components/auth-components.tsx
@@ -40,6 +40,15 @@ export function LoginProviders() {
     }
   };
 
+  const handleTestAdminUserSignIn = async () => {
+    const [email, password] = prompt(
+      "Enter email and password (space separated)",
+      "admin@example.com password",
+    )!.split(" ")!;
+    const result = await authClient.signIn.email({ email, password });
+    window.location.href = result.data?.url ?? "/";
+  };
+
   return (
     <div className="w-full space-y-3">
       <Button
@@ -76,6 +85,16 @@ export function LoginProviders() {
       >
         Continue with Slack
       </Button>
+      {import.meta.env.VITE_ENABLE_TEST_ADMIN_USER && (
+        <Button
+          onClick={handleTestAdminUserSignIn}
+          variant="outline"
+          size="lg"
+          className="w-full h-12 text-base font-medium"
+        >
+          Continue as test admin user
+        </Button>
+      )}
     </div>
   );
 }

--- a/apps/os/app/components/dashboard-layout.tsx
+++ b/apps/os/app/components/dashboard-layout.tsx
@@ -44,6 +44,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "../components/ui/dropdown-menu.tsx";
+import { useImpersonation } from "./impersonate.tsx";
 
 const navigation = [
   {
@@ -77,6 +78,8 @@ function UserSwitcher() {
   const navigate = useNavigate();
   const params = useParams();
   const currentEstateId = params.estateId;
+
+  const impersonation = useImpersonation();
 
   const currentEstate = estates?.find((e: Estate) => e.id === currentEstateId) || null;
 
@@ -163,9 +166,19 @@ function UserSwitcher() {
                     {currentEstateId === estate.id && <Check className="size-4" />}
                   </DropdownMenuItem>
                 ))}
-                <DropdownMenuSeparator />
               </>
             )}
+            {impersonation.isAdmin && (
+              <DropdownMenuItem onClick={() => impersonation.impersonate.mutate()}>
+                Impersonate another user
+              </DropdownMenuItem>
+            )}
+            {impersonation.impersonatedBy && (
+              <DropdownMenuItem onClick={() => impersonation.unimpersonate.mutate()}>
+                Stop impersonating
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuSeparator />
             <DropdownMenuItem onClick={handleLogout}>
               <LogOut className="mr-2 h-4 w-4" />
               <span>Log out</span>

--- a/apps/os/app/components/impersonate.tsx
+++ b/apps/os/app/components/impersonate.tsx
@@ -1,0 +1,34 @@
+"use client";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { authClient } from "../lib/auth-client.ts";
+import { useTRPC, useTRPCClient } from "../lib/trpc.ts";
+
+export const useImpersonation = () => {
+  const trpc = useTRPC();
+  const trpcClient = useTRPCClient();
+  const { data: impersonationInfo } = useQuery(trpc.admin.impersonationInfo.queryOptions());
+  const unimpersonate = useMutation({
+    mutationFn: () => authClient.admin.stopImpersonating(),
+    onSuccess: () => window.location.reload(),
+  });
+  const impersonate = useMutation({
+    mutationFn: async () => {
+      const userIdOrEmail = prompt("user id or email to impersonate");
+      if (!userIdOrEmail) return;
+      const user = userIdOrEmail.includes("@")
+        ? await trpcClient.admin.findUserByEmail.query({ email: userIdOrEmail })
+        : { id: userIdOrEmail };
+      if (!user) return;
+      const impersonateResult = await authClient.admin.impersonateUser({
+        userId: user.id,
+      });
+      if (impersonateResult.error) throw impersonateResult.error; // todo: have better auth throw errors by default
+      return impersonateResult.data;
+    },
+    onSuccess: (data) => {
+      if (data?.user?.email) window.location.reload();
+    },
+  });
+
+  return { unimpersonate, impersonate, ...impersonationInfo };
+};

--- a/apps/os/app/lib/auth-client.ts
+++ b/apps/os/app/lib/auth-client.ts
@@ -1,7 +1,8 @@
 import { createAuthClient } from "better-auth/react";
+import { adminClient } from "better-auth/client/plugins";
 import { integrationsClientPlugin } from "./integrations-client.ts";
 
 export const authClient = createAuthClient({
   baseURL: import.meta.env.VITE_PUBLIC_URL || "http://localhost:5173",
-  plugins: [integrationsClientPlugin()],
+  plugins: [adminClient(), integrationsClientPlugin()],
 });

--- a/apps/os/backend/auth/auth.ts
+++ b/apps/os/backend/auth/auth.ts
@@ -1,4 +1,5 @@
 import { betterAuth } from "better-auth";
+import { admin } from "better-auth/plugins";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { typeid } from "typeid-js";
 import { type DB } from "../db/client.ts";
@@ -20,7 +21,11 @@ export const getAuth = (db: DB) =>
         allowDifferentEmails: true,
       },
     },
-    plugins: [integrationsPlugin()],
+    // for now, we only want to enable email and password login if we know we need it for testing
+    ...(import.meta.env.VITE_ENABLE_TEST_ADMIN_USER
+      ? { emailAndPassword: { enabled: true } }
+      : ({} as never)), // need to cast to never to make typescript think we can call APIs like `auth.api.createUser` - but this will fail at runtime if we try to use it in production
+    plugins: [admin(), integrationsPlugin()],
     socialProviders: {
       google: {
         scope: [

--- a/apps/os/backend/db/migrations/0010_bizarre_fixer.sql
+++ b/apps/os/backend/db/migrations/0010_bizarre_fixer.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "session" ADD COLUMN "impersonated_by" text;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "role" text DEFAULT 'user';--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "banned" boolean;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "ban_reason" text;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "ban_expires" timestamp;

--- a/apps/os/backend/db/schema.ts
+++ b/apps/os/backend/db/schema.ts
@@ -25,6 +25,11 @@ export const user = pgTable("user", (t) => ({
   email: t.text().notNull().unique(),
   emailVerified: t.boolean().default(false).notNull(),
   image: t.text(),
+  // https://www.better-auth.com/docs/plugins/admin#schema
+  role: t.text().default("user"),
+  banned: t.boolean(),
+  banReason: t.text(),
+  banExpires: t.timestamp(),
   ...withTimestamps,
 }));
 export const userRelations = relations(user, ({ many }) => ({
@@ -41,6 +46,8 @@ export const session = pgTable("session", (t) => ({
   ipAddress: t.text(),
   userAgent: t.text(),
   userId: t.text().notNull(),
+  // https://www.better-auth.com/docs/plugins/admin#schema
+  impersonatedBy: t.text(),
   ...withTimestamps,
 }));
 export const sessionRelations = relations(session, ({ one }) => ({

--- a/apps/os/backend/trpc/root.ts
+++ b/apps/os/backend/trpc/root.ts
@@ -4,6 +4,7 @@ import { integrationsRouter } from "./routers/integrations.ts";
 import { estateRouter } from "./routers/estate.ts";
 import { estatesRouter } from "./routers/estates.ts";
 import { userRouter } from "./routers/user.ts";
+import { testingRouter } from "./routers/testing.ts";
 import { adminRouter } from "./routers/admin.ts";
 
 export const appRouter = router({
@@ -13,6 +14,7 @@ export const appRouter = router({
   estates: estatesRouter,
   user: userRouter,
   admin: adminRouter,
+  testing: testingRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/os/backend/trpc/root.ts
+++ b/apps/os/backend/trpc/root.ts
@@ -4,6 +4,7 @@ import { integrationsRouter } from "./routers/integrations.ts";
 import { estateRouter } from "./routers/estate.ts";
 import { estatesRouter } from "./routers/estates.ts";
 import { userRouter } from "./routers/user.ts";
+import { adminRouter } from "./routers/admin.ts";
 
 export const appRouter = router({
   integrations: integrationsRouter,
@@ -11,6 +12,7 @@ export const appRouter = router({
   estate: estateRouter,
   estates: estatesRouter,
   user: userRouter,
+  admin: adminRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/os/backend/trpc/routers/admin.ts
+++ b/apps/os/backend/trpc/routers/admin.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { protectedProcedure, router } from "../trpc.ts";
+import { schema } from "../../db/client.ts";
+
+const adminProcedure = protectedProcedure.use(({ ctx, next }) => {
+  if (ctx.user.role !== "admin") {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You are not authorized to access this resource",
+    });
+  }
+  return next({ ctx });
+});
+
+const findUserByEmail = adminProcedure
+  .input(z.object({ email: z.string() }))
+  .query(async ({ ctx, input }) => {
+    const user = await ctx.db.query.user.findFirst({
+      where: eq(schema.user.email, input.email),
+    });
+    return user;
+  });
+
+export const adminRouter = router({
+  findUserByEmail,
+  impersonationInfo: protectedProcedure.query(async ({ ctx }) => {
+    // || undefined means non-admins and non-impersonated users get `{}` from this endpoint, revealing no information
+    // important because it's available to anyone signed in
+    const impersonatedBy = ctx?.session?.session.impersonatedBy || undefined;
+    const isAdmin = ctx?.user?.role === "admin" || undefined;
+    return { impersonatedBy, isAdmin };
+  }),
+});

--- a/apps/os/backend/trpc/routers/testing.ts
+++ b/apps/os/backend/trpc/routers/testing.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import { publicProcedure, router } from "../trpc.ts";
+import { getAuth } from "../../auth/auth.ts";
+import { getDb, schema } from "../../db/client.ts";
+
+const createAdminUser = publicProcedure
+  .input(
+    z.object({
+      email: z.string().default("admin@example.com"),
+      password: z.string().default("password"),
+      name: z.string().optional(),
+    }),
+  )
+  .mutation(async ({ ctx, input }) => {
+    const auth = getAuth(ctx.db);
+    const _user = await auth.api
+      .createUser({
+        body: {
+          role: "admin",
+          name: input.name ?? input.email.split("@")[0],
+          email: input.email,
+          password: input.password,
+        },
+      })
+      .catch(async (e) => {
+        if (e.message.includes("already exists")) {
+          // const users = await auth.api.lis;
+          // return users.users[0];
+          return { created: false };
+        }
+        throw e;
+      });
+    return { created: true };
+  });
+
+const setUserRole = publicProcedure
+  .input(
+    z.object({
+      email: z.string(),
+      role: z.enum(["admin", "user"]),
+    }),
+  )
+  .mutation(async ({ input }) => {
+    const result = await getDb()
+      .update(schema.user)
+      .set({ role: input.role })
+      .where(eq(schema.user.email, input.email))
+      .returning();
+    return { success: true, result };
+  });
+
+/** At compile time, this router will be usable, but if you try to use it in production the procedures just won't exist (`as never`) */
+export const testingRouter = import.meta.env.VITE_ENABLE_TEST_ADMIN_USER
+  ? router({
+      createAdminUser,
+      setUserRole,
+    })
+  : (router({}) as never);


### PR DESCRIPTION
ITE-3008

Need the admin bits for the evals PR, but have done impersonation so I separated out since Nick had a ticket for it.

https://github.com/user-attachments/assets/3e9a64d2-3155-4b64-80b6-66faa85dc1ec

Implementation:

- add the `admin()` plugin from better-auth
- add admin migrations (new columns needed by the admin plugin)
- add the `adminClient()` plugin on the client side
- add an `adminRouter` to the root trpc. right now just a couple of procedures that admin users get access to.
   1. find a user by email
   2. check role/impersonatedBy 
- add a `testingRouter` to create an admin user if not exists (could add this to cli)
   - doesn't exist in production, based on doppler var
- add a log in as admin button (only show based on doppler var)
   - uses a lovely `prompt(...)` for email and passowrd
- add a button to impersonate a user by email (if logged in user is an admin)
   - uses a lovely `prompt(...)` for the user to impersonate's email
- add a button to stop impersonating (if current user is logged in via impesronation)
- refresh page on success because mutation invalidation didn't seem to be working