### PR TITLE
[WIP] Getting evals in braintrust

### DIFF
--- a/apps/os/evals/basic-conversation.eval.ts
+++ b/apps/os/evals/basic-conversation.eval.ts
@@ -13,7 +13,7 @@ evalite("agent knows when to end their turn", {
     return [
       {
         input: {
-          slug: "multi-turn conversation",
+          slug: "multi-turn fruits conversation",
           messages: [
             { message: "name a green fruit", expected: "a green fruit" },
             { message: "name another", expected: "a green fruit, not the same as the first" },
@@ -24,11 +24,27 @@ evalite("agent knows when to end their turn", {
           }),
         },
       },
+      {
+        input: {
+          slug: "multi-turn vegetables conversation",
+          messages: [
+            { message: "name a green vegetable", expected: "a green vegetable" },
+            { message: "name another", expected: "a green vegetable, not the same as the first" },
+            {
+              message: "name another",
+              expected: "a green vegetable, not the same as the 1st or 2nd",
+            },
+          ].map((m, i) => {
+            m.expected += `. penalize emojis by ${10 + i * 5}%`;
+            return m;
+          }),
+        },
+      },
     ];
   },
   task: async (input) => {
     const h = await createTestHelper(trpcClient, input.slug);
-    const scorer = multiTurnScorer();
+    const scorer = multiTurnScorer({ braintrustSpanExportedId: h.braintrustSpanExportedId });
 
     for (const message of input.messages) {
       const userMessage = await h.sendUserMessage(message.message);
@@ -36,12 +52,12 @@ evalite("agent knows when to end their turn", {
 
       scorer.scoreTurn([`user: ${message.message}`, `assistant: ${reply}`], message.expected);
     }
-    return { scores: await scorer.getScores() };
+
+    return {
+      scores: await scorer.getScores(),
+      braintrustSpanExportedId: h.braintrustSpanExportedId,
+    };
   },
-  scorers: [
-    multiTurnScorer.mean, //
-    multiTurnScorer.median,
-    multiTurnScorer.min,
-  ],
+  scorers: [multiTurnScorer.mean, multiTurnScorer.median, multiTurnScorer.min],
   columns: multiTurnScorer.renderColumns,
 });

--- a/apps/os/evals/helpers.ts
+++ b/apps/os/evals/helpers.ts
@@ -3,13 +3,13 @@ import { expect, vi } from "vitest";
 import { createTRPCClient, httpLink } from "@trpc/client";
 import { createAuthClient } from "better-auth/client";
 import { adminClient } from "better-auth/client/plugins";
+import { Eval, initLogger, type Span } from "braintrust";
 import type { AppRouter } from "../backend/trpc/root.ts";
 import type { AgentCoreEvent } from "../backend/agent/agent-core-schemas.ts";
 import type { MCPEvent } from "../backend/agent/mcp/mcp-slice.ts";
 import { type SlackSliceEvent } from "../backend/agent/slack-slice.ts";
 import type { SlackWebhookPayload } from "../backend/agent/slack.types.ts";
 import { testAdminUser } from "../backend/auth/test-admin.ts";
-import { Eval, initLogger, type Span } from "braintrust";
 
 export * from "./scorer.ts";
 

--- a/apps/os/evals/scorer.ts
+++ b/apps/os/evals/scorer.ts
@@ -3,8 +3,8 @@ import * as R from "remeda";
 import OpenAI from "openai";
 import { z } from "zod";
 import dedent from "dedent";
-import { zodTextFormat } from "./zod-openai.ts";
 import { startSpan } from "braintrust";
+import { zodTextFormat } from "./zod-openai.ts";
 
 const ScoreResult = z.object({
   score: z


### PR DESCRIPTION
DO NOT MERGE!
Thoughts:
- This is the minimal lightweight version of what we want. The only problem is that it puts each test case in its own experiment and it's a bit janky
- I would prefer making a custom `IterateEval` function which will run `evalite` with the braintrust logic.
  - It can create a braintrust experiment with the same name as the first parameter,
  - It will then create one eval span in that experiment for each of the test cases, with the same inputs, and we can then pass the exported ids as input into the `task` function,
  - The scorers are automatically wrapped with braintrust.

@mmkal what do you think about my above proposal? I think it would be fairly clean.