### PR TITLE
Avoid unfurling os.iterate.com authorization links

### DIFF
--- a/apps/os/backend/agent/slack-agent.ts
+++ b/apps/os/backend/agent/slack-agent.ts
@@ -668,8 +668,17 @@ export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsI
 
     const { endTurn, ...sendInput } = input;
 
-    const numLinks = sendInput.text.match(/https?:\/\/[^\s|]+/g)?.length;
-    const doUnfurl = sendInput.unfurl === "all" || (sendInput.unfurl === "auto" && numLinks === 1);
+    const links = sendInput.text.match(/https?:\/\/[^\s|]+/g) ?? [];
+    const hasOsIterateLink = links.some((link) => {
+      try {
+        return new URL(link).hostname === "os.iterate.com";
+      } catch {
+        return false;
+      }
+    });
+    const doUnfurl =
+      !hasOsIterateLink &&
+      (sendInput.unfurl === "all" || (sendInput.unfurl === "auto" && links.length === 1));
 
     const result = await this.slackAPI.chat.postMessage({
       channel: this.agentCore.state.slackChannelId as string,


### PR DESCRIPTION
## Summary
- prevent Slack messages from auto-unfurling when they contain os.iterate.com links
- ensure the sendSlackMessage helper recognises these links even when unfurling is explicitly requested

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dbeb2829c08333b84e463ce95cdb0e