### PR TITLE
Add admin impersonation option on estate access error

### DIFF
--- a/apps/os/app/routes/estate-layout.tsx
+++ b/apps/os/app/routes/estate-layout.tsx
@@ -1,11 +1,14 @@
-import { Outlet, redirect, isRouteErrorResponse, useRouteError } from "react-router";
+import { Outlet, redirect, isRouteErrorResponse, useRouteError, useParams } from "react-router";
 import { AlertCircle, Home } from "lucide-react";
+import { useMutation } from "@tanstack/react-query";
 import { getDb } from "../../backend/db/client.ts";
 import { getAuth } from "../../backend/auth/auth.ts";
 import { getUserEstateAccess } from "../../backend/trpc/trpc.ts";
 import { DashboardLayout } from "../components/dashboard-layout.tsx";
 import { Button } from "../components/ui/button.tsx";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "../components/ui/card.tsx";
+import { authClient } from "../lib/auth-client.ts";
+import { useTRPCClient } from "../lib/trpc.ts";
 import type { Route } from "./+types/estate-layout";
 
 // Server-side loader that checks estate access
@@ -75,6 +78,10 @@ export default function EstateLayout() {
 // Error boundary to display access errors nicely
 export function ErrorBoundary() {
   const error = useRouteError();
+  const params = useParams();
+  const { data: session } = authClient.useSession();
+  const trpcClient = useTRPCClient();
+  const estateId = params.estateId;
 
   let title: string;
   let message: string;
@@ -90,6 +97,28 @@ export function ErrorBoundary() {
     message = "Unknown error";
   }
 
+  const impersonateOwner = useMutation({
+    mutationFn: async () => {
+      if (!estateId) {
+        throw new Error("Missing estate identifier");
+      }
+
+      const owner = await trpcClient.admin.getEstateOwner.query({ estateId });
+      const impersonateResult = await authClient.admin.impersonateUser({ userId: owner.userId });
+
+      if (impersonateResult.error) {
+        throw impersonateResult.error;
+      }
+
+      return owner;
+    },
+    onSuccess: () => {
+      window.location.reload();
+    },
+  });
+
+  const isAdmin = session?.user?.role === "admin";
+
   return (
     <DashboardLayout>
       <div className="flex items-center justify-center min-h-[calc(100vh-8rem)] p-4">
@@ -103,13 +132,22 @@ export function ErrorBoundary() {
           <CardContent>
             <p className="text-sm text-muted-foreground text-center">{message}</p>
           </CardContent>
-          <CardFooter className="flex justify-center">
+          <CardFooter className="flex flex-wrap justify-center gap-2">
             <Button asChild>
               <a href="/">
                 <Home className="mr-2 h-4 w-4" />
                 Go to Home
               </a>
             </Button>
+            {isAdmin && estateId && (
+              <Button
+                variant="outline"
+                onClick={() => impersonateOwner.mutate()}
+                disabled={impersonateOwner.isPending}
+              >
+                {impersonateOwner.isPending ? "Impersonating..." : "Impersonate Estate Owner"}
+              </Button>
+            )}
           </CardFooter>
         </Card>
       </div>

--- a/apps/os/backend/agent/slack-agent.ts
+++ b/apps/os/backend/agent/slack-agent.ts
@@ -22,10 +22,7 @@ import {
 } from "./iterate-agent.ts";
 import { slackAgentTools } from "./slack-agent-tools.ts";
 import { slackSlice, type SlackSliceState } from "./slack-slice.ts";
-import {
-  shouldIncludeEventInConversation,
-  shouldUnfurlSlackMessage,
-} from "./slack-agent-utils.ts";
+import { shouldIncludeEventInConversation, shouldUnfurlSlackMessage } from "./slack-agent-utils.ts";
 import type {
   AgentCoreEvent,
   CoreReducedState,


### PR DESCRIPTION
## Summary
- add an admin tRPC query that finds the owning user for an estate
- surface an "Impersonate Estate Owner" action on the estate access error page when the viewer is an admin

## Testing
- pnpm --filter os lint *(fails: package has no "lint" script)*

------
https://chatgpt.com/codex/tasks/task_b_68dd06409dd4833383dddbf55bf08f28