### PR TITLE
Coding sandbox (WIP)

### DIFF
--- a/apps/os/backend/agent/context.ts
+++ b/apps/os/backend/agent/context.ts
@@ -87,6 +87,12 @@ export function forAgentClass(className: string) {
   return { type: "jsonata", expression } satisfies ContextRuleMatcher;
 }
 
+export function sandboxStatus(status: "starting" | "attached") {
+  // Construct JSONata expression that checks if agentCoreState.metadata.sandboxStatus matches the provided status
+  const expression = `agentCoreState.metadata.sandboxStatus = ${JSON.stringify(status)}`;
+  return { type: "jsonata", expression } satisfies ContextRuleMatcher;
+}
+
 export const matchers = {
   never,
   always,
@@ -97,6 +103,7 @@ export const matchers = {
   hasTool,
   hasMCPConnection,
   forAgentClass,
+  sandboxStatus,
   and,
   or,
   not,

--- a/apps/os/backend/agent/default-context-rules.ts
+++ b/apps/os/backend/agent/default-context-rules.ts
@@ -169,11 +169,6 @@ const defaultSlackAgentPrompt = dedent`
    - If you're asked to generate or edit an image of "me" or another Slack participant (e.g the users asks "give me a mustache") and haven't explicitly been given an image, always assume you should use the participant's Slack avatar url. 
      - If the user hasn't specified what kind of modified image they want, assume they want an emoji-styled image.
   - For emojis or logos: use a transparent background unless the user has specified otherwise. 
-
-  ### Running commands
-  - Use exec tool for running shell commands in sandbox
-  - exec tool runs in an isolated directory in the filesystem
-  - subdirectory \`repo\` contains useful persistent files (known as estate repo or context repo)
 `;
 export const defaultContextRules = defineRules([
   {
@@ -202,7 +197,6 @@ export const defaultContextRules = defineRules([
         ),
       }),
       iterateAgentTool.generateImage(),
-      iterateAgentTool.exec(),
       slackAgentTool.sendSlackMessage({
         overrideInputJSONSchema: z.toJSONSchema(
           slackAgentTools.sendSlackMessage.input.pick({
@@ -215,22 +209,6 @@ export const defaultContextRules = defineRules([
         ),
       }),
     ],
-  },
-  {
-    key: "sandbox-starting",
-    prompt: dedent`
-      The sandbox is currently starting up. This takes approximately 10 seconds.
-      When you run exec commands, the sandbox will automatically be initialized if it's not already running.
-    `,
-    match: matchers.sandboxStatus("starting"),
-  },
-  {
-    key: "sandbox-attached",
-    prompt: dedent`
-      The sandbox is currently running and attached.
-      You can execute commands immediately using the exec tool.
-    `,
-    match: matchers.sandboxStatus("attached"),
   },
   {
     key: "using-linear",
@@ -266,5 +244,21 @@ export const defaultContextRules = defineRules([
       - Never show raw Notion URLs in results - always wrap them in Slack link format
     `,
     match: matchers.hasMCPConnection("mcp.notion.com"),
+  },
+  {
+    key: "sandbox-starting",
+    prompt: dedent`
+      The sandbox is currently starting up. This takes approximately 10 seconds.
+      When you run exec commands, the sandbox will automatically be initialized if it's not already running.
+    `,
+    match: matchers.sandboxStatus("starting"),
+  },
+  {
+    key: "sandbox-attached",
+    prompt: dedent`
+      The sandbox is currently running and attached.
+      You can execute commands immediately using the exec tool.
+    `,
+    match: matchers.sandboxStatus("attached"),
   },
 ]);

--- a/apps/os/backend/agent/default-context-rules.ts
+++ b/apps/os/backend/agent/default-context-rules.ts
@@ -170,8 +170,8 @@ const defaultSlackAgentPrompt = dedent`
      - If the user hasn't specified what kind of modified image they want, assume they want an emoji-styled image.
   - For emojis or logos: use a transparent background unless the user has specified otherwise. 
 
-  ### Shell commands
-  - Use local_shell tool for running shell commands
+  ### Running commands
+  - Use exec tool for running shell commands in sandbox
 `;
 export const defaultContextRules = defineRules([
   {
@@ -200,7 +200,7 @@ export const defaultContextRules = defineRules([
         ),
       }),
       iterateAgentTool.generateImage(),
-      iterateAgentTool.local_shell(),
+      iterateAgentTool.exec(),
       slackAgentTool.sendSlackMessage({
         overrideInputJSONSchema: z.toJSONSchema(
           slackAgentTools.sendSlackMessage.input.pick({

--- a/apps/os/backend/agent/default-context-rules.ts
+++ b/apps/os/backend/agent/default-context-rules.ts
@@ -169,6 +169,9 @@ const defaultSlackAgentPrompt = dedent`
    - If you're asked to generate or edit an image of "me" or another Slack participant (e.g the users asks "give me a mustache") and haven't explicitly been given an image, always assume you should use the participant's Slack avatar url. 
      - If the user hasn't specified what kind of modified image they want, assume they want an emoji-styled image.
   - For emojis or logos: use a transparent background unless the user has specified otherwise. 
+
+  ### Modifying estate
+  - Use the modifyEstate tool for updating your own rules defined in the estate
 `;
 export const defaultContextRules = defineRules([
   {
@@ -197,6 +200,7 @@ export const defaultContextRules = defineRules([
         ),
       }),
       iterateAgentTool.generateImage(),
+      iterateAgentTool.modifyEstate(),
       slackAgentTool.sendSlackMessage({
         overrideInputJSONSchema: z.toJSONSchema(
           slackAgentTools.sendSlackMessage.input.pick({

--- a/apps/os/backend/agent/default-context-rules.ts
+++ b/apps/os/backend/agent/default-context-rules.ts
@@ -172,6 +172,8 @@ const defaultSlackAgentPrompt = dedent`
 
   ### Running commands
   - Use exec tool for running shell commands in sandbox
+  - exec tool runs in an isolated directory in the filesystem
+  - subdirectory \`repo\` contains useful persistent files (known as estate repo or context repo)
 `;
 export const defaultContextRules = defineRules([
   {

--- a/apps/os/backend/agent/default-context-rules.ts
+++ b/apps/os/backend/agent/default-context-rules.ts
@@ -170,8 +170,8 @@ const defaultSlackAgentPrompt = dedent`
      - If the user hasn't specified what kind of modified image they want, assume they want an emoji-styled image.
   - For emojis or logos: use a transparent background unless the user has specified otherwise. 
 
-  ### Modifying estate
-  - Use the modifyEstate tool for updating your own rules defined in the estate
+  ### Shell commands
+  - Use local_shell tool for running shell commands
 `;
 export const defaultContextRules = defineRules([
   {
@@ -200,7 +200,7 @@ export const defaultContextRules = defineRules([
         ),
       }),
       iterateAgentTool.generateImage(),
-      iterateAgentTool.modifyEstate(),
+      iterateAgentTool.local_shell(),
       slackAgentTool.sendSlackMessage({
         overrideInputJSONSchema: z.toJSONSchema(
           slackAgentTools.sendSlackMessage.input.pick({

--- a/apps/os/backend/agent/default-context-rules.ts
+++ b/apps/os/backend/agent/default-context-rules.ts
@@ -217,6 +217,22 @@ export const defaultContextRules = defineRules([
     ],
   },
   {
+    key: "sandbox-starting",
+    prompt: dedent`
+      The sandbox is currently starting up. This takes approximately 10 seconds.
+      When you run exec commands, the sandbox will automatically be initialized if it's not already running.
+    `,
+    match: matchers.sandboxStatus("starting"),
+  },
+  {
+    key: "sandbox-attached",
+    prompt: dedent`
+      The sandbox is currently running and attached.
+      You can execute commands immediately using the exec tool.
+    `,
+    match: matchers.sandboxStatus("attached"),
+  },
+  {
     key: "using-linear",
     prompt: dedent`
       When using Linear tools:

--- a/apps/os/backend/agent/iterate-agent-tools.ts
+++ b/apps/os/backend/agent/iterate-agent-tools.ts
@@ -160,11 +160,10 @@ export const iterateAgentTools = defineDOTools({
       overrideReplicateParams: z.record(z.string(), z.any()).optional(),
     }),
   },
-  modifyEstate: {
-    description: "Modify estate by updating its repo and rebuilding.",
-    input: z.object({
-      prompt: z.string(),
-      model: z.enum(SUPPORTED_MODELS).default(DEFAULT_MODEL),
-    }),
+  // NOTE: local_shell doesn't require any further parameters
+  // - https://platform.openai.com/docs/guides/tools-local-shell
+  // - https://github.com/vercel/ai/blob/main/packages/openai/src/responses/openai-responses-api-types.ts#L206-L208
+  local_shell: {
+    description: "Execute shell in a sandbox",
   },
 });

--- a/apps/os/backend/agent/iterate-agent-tools.ts
+++ b/apps/os/backend/agent/iterate-agent-tools.ts
@@ -2,7 +2,6 @@ import dedent from "dedent";
 import z from "zod";
 import { defineDOTools } from "./do-tools.ts";
 import { IntegrationMode, MCPParam } from "./tool-schemas.ts";
-import { DEFAULT_MODEL, SUPPORTED_MODELS } from "./agent-core-schemas.ts";
 
 export type IterateAgentToolInterface = typeof iterateAgentTools.$infer.interface;
 export type IterateAgentToolInputs = typeof iterateAgentTools.$infer.inputTypes;

--- a/apps/os/backend/agent/iterate-agent-tools.ts
+++ b/apps/os/backend/agent/iterate-agent-tools.ts
@@ -2,6 +2,7 @@ import dedent from "dedent";
 import z from "zod";
 import { defineDOTools } from "./do-tools.ts";
 import { IntegrationMode, MCPParam } from "./tool-schemas.ts";
+import { DEFAULT_MODEL, SUPPORTED_MODELS } from "./agent-core-schemas.ts";
 
 export type IterateAgentToolInterface = typeof iterateAgentTools.$infer.interface;
 export type IterateAgentToolInputs = typeof iterateAgentTools.$infer.inputTypes;
@@ -157,6 +158,13 @@ export const iterateAgentTools = defineDOTools({
       quality: z.enum(["low", "medium", "high"]).default("high"),
       background: z.enum(["auto", "transparent", "opaque"]).default("auto"),
       overrideReplicateParams: z.record(z.string(), z.any()).optional(),
+    }),
+  },
+  modifyEstate: {
+    description: "Modify estate by updating its repo and rebuilding.",
+    input: z.object({
+      prompt: z.string(),
+      model: z.enum(SUPPORTED_MODELS).default(DEFAULT_MODEL),
     }),
   },
 });

--- a/apps/os/backend/agent/iterate-agent-tools.ts
+++ b/apps/os/backend/agent/iterate-agent-tools.ts
@@ -161,10 +161,9 @@ export const iterateAgentTools = defineDOTools({
     }),
   },
   exec: {
-    description: "Execute a shell in a sandbox",
+    description: "Execute a shell in a sandbox.",
     input: z.object({
       command: z.string(),
-      workingDirectory: z.string().optional(),
       env: z.record(z.string(), z.string()).optional(),
     }),
   },

--- a/apps/os/backend/agent/iterate-agent-tools.ts
+++ b/apps/os/backend/agent/iterate-agent-tools.ts
@@ -160,10 +160,12 @@ export const iterateAgentTools = defineDOTools({
       overrideReplicateParams: z.record(z.string(), z.any()).optional(),
     }),
   },
-  // NOTE: local_shell doesn't require any further parameters
-  // - https://platform.openai.com/docs/guides/tools-local-shell
-  // - https://github.com/vercel/ai/blob/main/packages/openai/src/responses/openai-responses-api-types.ts#L206-L208
-  local_shell: {
-    description: "Execute shell in a sandbox",
+  exec: {
+    description: "Execute a shell in a sandbox",
+    input: z.object({
+      command: z.string(),
+      workingDirectory: z.string().optional(),
+      env: z.record(z.string(), z.string()).optional(),
+    }),
   },
 });

--- a/apps/os/backend/agent/iterate-agent.ts
+++ b/apps/os/backend/agent/iterate-agent.ts
@@ -1358,7 +1358,7 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
       repository_id: estate.connectedRepoId,
     });
     const githubRepoUrl = repoData.html_url;
-    const branch = estate.connectedRepoRef || "main";
+    const branch = estate.connectedRepoRef || repoData.default_branch || "main";
     const commitHash = undefined; // Use the latest commit on the branch
 
     // ------------------------------------------------------------------------

--- a/apps/os/backend/agent/iterate-agent.ts
+++ b/apps/os/backend/agent/iterate-agent.ts
@@ -1383,6 +1383,18 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
     // Retrieve the sandbox
     const sandbox = getSandbox(env.SANDBOX, sandboxId);
 
+    // Check current state
+    // NOTE: according to the exposed API this should be the correct way to
+    // check if the sandbox is running and start it up if it isnt'. But the logs
+    // are confusing:
+    // ... Sandbox successfully shut down
+    // ... Error checking if container is ready: connect(): Connection refused: container port not found. Make sure you exposed the port in your container definition.
+    // ... Error checking if container is ready: The operation was aborted
+    // ... Port 3000 is ready
+    if ((await sandbox.getState()).status !== "healthy") {
+      await sandbox.startAndWaitForPorts(3000); // default sandbox port
+    }
+
     // Ensure that the session directory exists
     await sandbox.mkdir(sessionDir, { recursive: true });
 

--- a/apps/os/backend/agent/iterate-agent.ts
+++ b/apps/os/backend/agent/iterate-agent.ts
@@ -1351,22 +1351,12 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
     const { getGithubInstallationToken } = await import("../integrations/github/github-utils.ts");
     const githubToken = await getGithubInstallationToken(githubInstallation.accountId);
 
-    // Fetch repository details from GitHub API
-    const repoResponse = await fetch(
-      `https://api.github.com/repositories/${estate.connectedRepoId}`,
-      {
-        headers: {
-          Authorization: `Bearer ${githubToken}`,
-          "User-Agent": "Iterate OS",
-        },
-      },
-    );
-
-    if (!repoResponse.ok) {
-      throw new Error(`Failed to fetch repository details: ${repoResponse.statusText}`);
-    }
-
-    const repoData = (await repoResponse.json()) as { html_url: string };
+    // Fetch repository details using Octokit
+    const { Octokit } = await import("octokit");
+    const octokit = new Octokit({ auth: githubToken });
+    const { data: repoData } = await octokit.request("GET /repositories/{repository_id}", {
+      repository_id: estate.connectedRepoId,
+    });
     const githubRepoUrl = repoData.html_url;
     const branch = estate.connectedRepoRef || "main";
     const commitHash = undefined; // Use the latest commit on the branch

--- a/apps/os/backend/agent/iterate-agent.ts
+++ b/apps/os/backend/agent/iterate-agent.ts
@@ -1306,29 +1306,12 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
     };
   }
 
-  async modifyEstate(input: Inputs["modifyEstate"]) {
+  async local_shell(input: Inputs["local_shell"]) {
     console.info("TODO-REMOVE-001", input);
-
-    // TODO-REMOVE
-    const estateId = "est_01k6cyfg4ze01td6fhhx15zebb";
-    const commitHash = "92985e927488470f770cef6b9cf78f41e966fd20";
-    const commitMessage = "Update rules";
-
-    // Use the helper function to trigger the rebuild
-    const build = await triggerEstateRebuild({
-      db: this.db,
-      env: this.env,
-      estateId,
-      commitHash,
-      commitMessage,
-      isManual: true,
-    });
 
     return {
       success: true,
-      buildId: build.id,
-      status: "in_progress",
-      message: "Build triggered successfully",
+      message: "Shell command executed",
     };
   }
 }

--- a/apps/os/backend/agent/iterate-agent.ts
+++ b/apps/os/backend/agent/iterate-agent.ts
@@ -1304,6 +1304,14 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
       __addAgentCoreEvents: fileSharedEvents,
     };
   }
+
+  async modifyEstate(input: Inputs["modifyEstate"]) {
+    console.info("TODO-REMOVE-001", input);
+    return {
+      success: true,
+      message: `Modified estate.`,
+    };
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/apps/os/backend/agent/iterate-agent.ts
+++ b/apps/os/backend/agent/iterate-agent.ts
@@ -51,6 +51,7 @@ import { toolSpecsToImplementations } from "./tool-spec-to-runtime-tool.ts";
 import { defaultContextRules } from "./default-context-rules.ts";
 import { ContextRule } from "./context-schemas.ts";
 import { processPosthogAgentCoreEvent } from "./posthog-event-processor.ts";
+import { triggerEstateRebuild } from "../trpc/routers/estate.ts";
 
 // -----------------------------------------------------------------------------
 // Core slice definition – *always* included for any IterateAgent variant.
@@ -1307,9 +1308,27 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
 
   async modifyEstate(input: Inputs["modifyEstate"]) {
     console.info("TODO-REMOVE-001", input);
+
+    // TODO-REMOVE
+    const estateId = "est_01k6cyfg4ze01td6fhhx15zebb";
+    const commitHash = "92985e927488470f770cef6b9cf78f41e966fd20";
+    const commitMessage = "Update rules";
+
+    // Use the helper function to trigger the rebuild
+    const build = await triggerEstateRebuild({
+      db: this.db,
+      env: this.env,
+      estateId,
+      commitHash,
+      commitMessage,
+      isManual: true,
+    });
+
     return {
       success: true,
-      message: `Modified estate.`,
+      buildId: build.id,
+      status: "in_progress",
+      message: "Build triggered successfully",
     };
   }
 }

--- a/apps/os/backend/agent/iterate-agent.ts
+++ b/apps/os/backend/agent/iterate-agent.ts
@@ -1306,7 +1306,7 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
     };
   }
 
-  async local_shell(input: Inputs["local_shell"]) {
+  async exec(input: Inputs["exec"]) {
     console.info("TODO-REMOVE-001", input);
 
     return {

--- a/apps/os/backend/agent/iterate-agent.ts
+++ b/apps/os/backend/agent/iterate-agent.ts
@@ -1460,7 +1460,7 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
                   status: "completed", // ← Changed from "pending"
                 },
                 result: {
-                  success: true,
+                  success: resultExec.success,
                   output: {},
                 },
               },
@@ -1481,7 +1481,7 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
     // If sandbox is already running, just run the command
     const resultExec = await execInSandbox();
     return {
-      success: true,
+      success: resultExec.success,
       message: resultExec.stdout,
       __addAgentCoreEvents: [{ type: "CORE:SET_METADATA", data: { sandboxStatus: "attached" } }],
     };

--- a/apps/os/backend/agent/iterate-agent.ts
+++ b/apps/os/backend/agent/iterate-agent.ts
@@ -1415,8 +1415,6 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
       return _resultExec;
     };
 
-    console.log("TO-REMOVE-LATER: checking if sandbox is running");
-
     // If sandbox is not ready, start it, and schedule exec after it boots up.
     // NOTE: according to the exposed API this should be the correct way to
     //       check if the sandbox is running and start it up if it isnt'. But
@@ -1432,8 +1430,6 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
           .startAndWaitForPorts(3000) // default sandbox port
           .then(execInSandbox)
           .then((resultExec) => {
-            console.log("TO-REMOVE-LATER: received exec result in callback");
-
             // Inject a tool call event that will be processed by the agent
             // TODO: this doesn't work
             (this as any).addEvent({
@@ -1458,8 +1454,6 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
             });
           }),
       );
-
-      console.log("TO-REMOVE-LATER: sandbox is not yet running, so we wait for it to boot up");
 
       // TODO: this doesn't work
       return {

--- a/apps/os/backend/integrations/github/github-utils.ts
+++ b/apps/os/backend/integrations/github/github-utils.ts
@@ -124,7 +124,7 @@ export async function triggerGithubBuild(params: {
   commitMessage: string;
   repoUrl: string;
   installationToken: string;
-  workingDirectory?: string;
+  connectedRepoPath?: string;
   branch?: string;
   webhookId?: string;
   workflowRunId?: string;
@@ -138,7 +138,7 @@ export async function triggerGithubBuild(params: {
     commitMessage,
     repoUrl,
     installationToken,
-    workingDirectory,
+    connectedRepoPath,
     branch,
     webhookId,
     workflowRunId,
@@ -193,7 +193,7 @@ export async function triggerGithubBuild(params: {
     githubToken: installationToken,
     commitHash,
     branch,
-    workingDirectory: workingDirectory || "/",
+    connectedRepoPath: connectedRepoPath || "/",
     callbackUrl,
     buildId: build.id,
     estateId,

--- a/apps/os/backend/integrations/github/router.ts
+++ b/apps/os/backend/integrations/github/router.ts
@@ -232,7 +232,7 @@ githubApp.post("/webhook", async (c) => {
       commitMessage: commitMessage || "No commit message",
       repoUrl,
       installationToken,
-      workingDirectory: estate.connectedRepoPath || undefined,
+      connectedRepoPath: estate.connectedRepoPath || undefined,
       branch: estate.connectedRepoRef || "main",
       webhookId: event.id || `webhook-${Date.now()}`,
       workflowRunId: event.workflow_run?.id?.toString(),

--- a/apps/os/backend/sandbox/Dockerfile
+++ b/apps/os/backend/sandbox/Dockerfile
@@ -13,6 +13,13 @@ RUN apt-get remove -y nodejs npm && \
 # Install pnpm and tsx using Node 24
 RUN npm install -g pnpm tsx
 
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y gh
+
 COPY sandbox-entry.ts /tmp/sandbox-entry.ts
 RUN chmod +x /tmp/sandbox-entry.ts
 

--- a/apps/os/backend/sandbox/Dockerfile
+++ b/apps/os/backend/sandbox/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get remove -y nodejs npm && \
 # Install pnpm and tsx using Node 24
 RUN npm install -g pnpm tsx
 
-COPY build-script.ts /tmp/build-script.ts
-RUN chmod +x /tmp/build-script.ts
+COPY sandbox-entry.ts /tmp/sandbox-entry.ts
+RUN chmod +x /tmp/sandbox-entry.ts
 
 # Expose the ports you want to expose
 EXPOSE 3000

--- a/apps/os/backend/sandbox/Dockerfile
+++ b/apps/os/backend/sandbox/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get remove -y nodejs npm && \
     ln -sf /usr/local/bin/npm /usr/bin/npm && \
     ln -sf /usr/local/bin/npx /usr/bin/npx
 
-
 # Install pnpm and tsx using Node 24
 RUN npm install -g pnpm tsx
 

--- a/apps/os/backend/sandbox/run-config.ts
+++ b/apps/os/backend/sandbox/run-config.ts
@@ -62,15 +62,14 @@ async function runConfigInSandboxInternal(
     estateId,
   } = options;
 
-  // Compute IDs
-  const sandboxId = `agent-sandbox-${estateId}`;
-  const sessionId = estateId;
-  const sessionDir = `/tmp/session-${estateId}`;
-
   // Retrieve the sandbox
+  const sandboxId = `agent-sandbox-${estateId}`;
   const sandbox = getSandbox(env.SANDBOX, sandboxId);
 
   // Ensure that the session directory exists
+  const sessionId = estateId;
+  // IMPORTANT: Randomize the session dir so build always works with the clean repo
+  const sessionDir = `/tmp/session-${estateId}-${Math.random().toString().slice(2)}`;
   await sandbox.mkdir(sessionDir, { recursive: true });
 
   // Create an isolated session
@@ -102,6 +101,7 @@ async function runConfigInSandboxInternal(
 
   // Prepare arguments as a JSON object
   const buildArgs = {
+    // Ensure we use a clean clone
     sessionDir,
     connectedRepoPath,
     callbackUrl: callbackUrl || "",

--- a/apps/os/backend/sandbox/sandbox-entry.ts
+++ b/apps/os/backend/sandbox/sandbox-entry.ts
@@ -232,8 +232,7 @@ async function subcommandInit(args: InitArgs) {
     process.exit(1);
   }
 
-  const segments = [args.sessionDir, "repo"];
-  const repoDir = path.join(...segments);
+  const repoDir = args.sessionDir;
 
   console.error("=== Starting sandbox init ===");
   console.error(`Repository: ${args.githubRepoUrl}`);
@@ -262,7 +261,7 @@ async function subcommandInit(args: InitArgs) {
     console.error("=== Cloning repository ===");
 
     // Build clone arguments with optimizations
-    const cloneArgs = ["repo", "clone", args.githubRepoUrl, repoDir];
+    const cloneArgs = ["clone", args.githubRepoUrl, repoDir];
 
     // For branches/tags, use shallow clone and combine with checkout
     // For commit hashes, we need full history (or at least more depth)
@@ -314,10 +313,10 @@ async function subcommandBuild(args: BuildArgs) {
     process.exit(1);
   }
 
-  const segments = [args.sessionDir, "repo"];
-  const repoDir = path.join(...segments);
-  if (args.connectedRepoPath) segments.push(args.connectedRepoPath);
-  const workDir = path.join(...segments);
+  const repoDir = args.sessionDir;
+  const workDir = args.connectedRepoPath
+    ? path.join(args.sessionDir, args.connectedRepoPath)
+    : args.sessionDir;
 
   console.error("=== Starting building process ===");
   console.error(`Repo directory: ${repoDir}`);

--- a/apps/os/backend/sandbox/sandbox-entry.ts
+++ b/apps/os/backend/sandbox/sandbox-entry.ts
@@ -274,7 +274,7 @@ async function subcommandInit(args: InitArgs) {
       console.error("=== Cloning repository ===");
 
       // Build clone arguments with optimizations
-      const cloneArgs = ["clone", args.githubRepoUrl, repoDir];
+      const cloneArgs = ["repo", "clone", args.githubRepoUrl, repoDir];
 
       // For branches/tags, use shallow clone and combine with checkout
       // For commit hashes, we need full history (or at least more depth)

--- a/apps/os/backend/sandbox/sandbox-entry.ts
+++ b/apps/os/backend/sandbox/sandbox-entry.ts
@@ -255,6 +255,9 @@ async function subcommandInit(args: InitArgs) {
       process.exit(1);
     }
 
+    // Configure git with the credential from gh
+    await execCommand("gh", ["auth", "setup-git"]);
+
     // Clone the repository using gh (optimized: combine clone + checkout when possible)
     console.error("=== Cloning repository ===");
 

--- a/apps/os/backend/trpc/routers/estate.ts
+++ b/apps/os/backend/trpc/routers/estate.ts
@@ -78,7 +78,7 @@ export async function triggerEstateRebuild(params: {
     commitMessage,
     repoUrl: repoData.clone_url,
     installationToken,
-    workingDirectory: estateWithRepo.connectedRepoPath || "/",
+    connectedRepoPath: estateWithRepo.connectedRepoPath || "/",
     branch: estateWithRepo.connectedRepoRef || "main",
     isManual,
   });

--- a/apps/os/backend/utils/utils.ts
+++ b/apps/os/backend/utils/utils.ts
@@ -48,3 +48,14 @@ export function replaceLocalhostWithNgrok(url: string): string {
   }
   return url;
 }
+
+// Hashes any string to a number in the range [0, max-1]
+export function hashStringToRange(str: string, max: number): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash; // Convert to 32-bit integer
+  }
+  return Math.abs(hash) % max;
+}

--- a/apps/os/backend/utils/utils.ts
+++ b/apps/os/backend/utils/utils.ts
@@ -48,14 +48,3 @@ export function replaceLocalhostWithNgrok(url: string): string {
   }
   return url;
 }
-
-// Hashes any string to a number in the range [0, max-1]
-export function hashStringToRange(str: string, max: number): number {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    const char = str.charCodeAt(i);
-    hash = (hash << 5) - hash + char;
-    hash = hash & hash; // Convert to 32-bit integer
-  }
-  return Math.abs(hash) % max;
-}

--- a/apps/os/backend/worker.ts
+++ b/apps/os/backend/worker.ts
@@ -214,11 +214,11 @@ app.post(
         .string()
         .regex(/^[a-f0-9]{7,40}$/i, "Invalid commit hash format")
         .optional(),
-      workingDirectory: z
+      connectedRepoPath: z
         .string()
         .refine(
           (val) => !val || !val.startsWith("/"),
-          "Working directory should be a relative path within the repository",
+          "Directory to use within the connected repository",
         )
         .optional(),
     }),

--- a/apps/os/package.json
+++ b/apps/os/package.json
@@ -58,6 +58,7 @@
     "jsonata": "github:mmkal/jsonata#23fbb59fa991213b29f732c91d9e2e455733f337",
     "lucide-react": "^0.544.0",
     "next-themes": "^0.4.6",
+    "octokit": "^5.0.3",
     "openai": "^5.20.3",
     "p-queue": "^8.1.1",
     "p-suite": "^0.3.0",

--- a/estates/iterate/iterate.config.ts
+++ b/estates/iterate/iterate.config.ts
@@ -1,6 +1,28 @@
-import { defineConfig, contextRulesFromFiles } from "@iterate-com/sdk";
+import { defineConfig, contextRulesFromFiles, tools, matchers, dedent } from "@iterate-com/sdk";
 
 const config = defineConfig({
-  contextRules: [...contextRulesFromFiles("rules/**/*.md")],
+  contextRules: [
+    ...contextRulesFromFiles("rules/**/*.md"),
+    {
+      key: "testing-sandboxes",
+      prompt: dedent`
+        ### Estate repo container sandbox, exec tool and use of the filesystem
+        - You are running in the context of a docker container, which has a copy of your "estate repository" checked out
+        - The estate repository contains the very instructions you are reading right now
+        - One of your most important skills is to update your own estate repo
+        - The entry point for your configuration is in iterate.config.ts
+        - To interact with the docker container, use the exec tool
+        - If you like, you can make yourself files such as a PLAN.md or similar to organise your work for longer tasks
+        - When asked to "commit changes" or "make a pull request", always do the following
+          - use \`git\` to make a branch, commit and push to origin
+          - use \`gh\` to make a pull request for the branch after pushing it
+          - don't worry about authentication
+        - Use exec tool for running shell commands in sandbox
+      `,
+      tools: [tools.exec()],
+      // this is the #agents-with-sandboxes channel
+      match: matchers.slackChannel("C09JH97Q0RL"),
+    },
+  ],
 });
 export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      octokit:
+        specifier: ^5.0.3
+        version: 5.0.3
       openai:
         specifier: ^5.20.3
         version: 5.20.3(ws@8.18.0)(zod@4.1.8)
@@ -2003,6 +2006,119 @@ packages:
     resolution: {integrity: sha512-gGq0NJkIGSwdbUt4yhdF8ZrmkGKVz9vAdVzpOfnom+V8PLSmSOVhZwbNvZZS1EYcJN5hzzKBxmmVVAInM6HQLg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  '@octokit/app@16.1.1':
+    resolution: {integrity: sha512-pcvKSN6Q6aT3gU5heoDFs3ywU5xejxeqs1rQpUwgN7CmBlxCSy9aCoqFuC6GpVv71O/Qq/VuYfCNzrOZp/9Ycw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-app@8.1.1':
+    resolution: {integrity: sha512-yW9YUy1cuqWlz8u7908ed498wJFt42VYsYWjvepjojM4BdZSp4t+5JehFds7LfvYi550O/GaUI94rgbhswvxfA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-app@9.0.2':
+    resolution: {integrity: sha512-vmjSHeuHuM+OxZLzOuoYkcY3OPZ8erJ5lfswdTmm+4XiAKB5PmCk70bA1is4uwSl/APhRVAv4KHsgevWfEKIPQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-device@8.0.2':
+    resolution: {integrity: sha512-KW7Ywrz7ei7JX+uClWD2DN1259fnkoKuVdhzfpQ3/GdETaCj4Tx0IjvuJrwhP/04OhcMu5yR6tjni0V6LBihdw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-user@6.0.1':
+    resolution: {integrity: sha512-vlKsL1KUUPvwXpv574zvmRd+/4JiDFXABIZNM39+S+5j2kODzGgjk7w5WtiQ1x24kRKNaE7v9DShNbw43UA3Hw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-unauthenticated@7.0.2':
+    resolution: {integrity: sha512-vjcPRP1xsKWdYKiyKmHkLFCxeH4QvVTv05VJlZxwNToslBFcHRJlsWRaoI2+2JGCf9tIM99x8cN0b1rlAHJiQw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.5':
+    resolution: {integrity: sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.1':
+    resolution: {integrity: sha512-7P1dRAZxuWAOPI7kXfio88trNi/MegQ0IJD3vfgC3b+LZo1Qe6gRJc2v0mz2USWWJOKrB2h5spXCzGbw+fAdqA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.2':
+    resolution: {integrity: sha512-iz6KzZ7u95Fzy9Nt2L8cG88lGRMr/qy1Q36ih/XVzMIlPDMYwaNLE/ENhqmIzgPrlNWiYJkwmveEetvxAgFBJw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-app@8.0.2':
+    resolution: {integrity: sha512-Oln8yKrDIDKnp49GUCSqda+XZyocmNapumjA0JdTpRfwMpmFMnh3bCOtSgb3X/kHfdtT7Q9ihFeN1djn58forg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-authorization-url@8.0.0':
+    resolution: {integrity: sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-methods@6.0.1':
+    resolution: {integrity: sha512-xi6Iut3izMCFzXBJtxxJehxJmAKjE8iwj6L5+raPRwlTNKAbOOBJX7/Z8AF5apD4aXvc2skwIdOnC+CQ4QuA8Q==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@25.1.0':
+    resolution: {integrity: sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==}
+
+  '@octokit/openapi-types@26.0.0':
+    resolution: {integrity: sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA==}
+
+  '@octokit/openapi-webhooks-types@12.0.3':
+    resolution: {integrity: sha512-90MF5LVHjBedwoHyJsgmaFhEN1uzXyBDRLEBe7jlTYx/fEhPAk3P3DAJsfZwC54m8hAIryosJOL+UuZHB3K3yA==}
+
+  '@octokit/plugin-paginate-graphql@6.0.0':
+    resolution: {integrity: sha512-crfpnIoFiBtRkvPqOyLOsw12XsveYuY2ieP6uYDosoUegBJpSVxGwut9sxUgFFcll3VTOTqpUf8yGd8x1OmAkQ==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-paginate-rest@13.2.0':
+    resolution: {integrity: sha512-YuAlyjR8o5QoRSOvMHxSJzPtogkNMgeMv2mpccrvdUGeC3MKyfi/hS+KiFwyH/iRKIKyx+eIMsDjbt3p9r2GYA==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@16.1.0':
+    resolution: {integrity: sha512-nCsyiKoGRnhH5LkH8hJEZb9swpqOcsW+VXv1QoyUNQXJeVODG4+xM6UICEqyqe9XFr6LkL8BIiFCPev8zMDXPw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-retry@8.0.2':
+    resolution: {integrity: sha512-mVPCe77iaD8g1lIX46n9bHPUirFLzc3BfIzsZOpB7bcQh1ecS63YsAgcsyMGqvGa2ARQWKEFTrhMJX2MLJVHVw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=7'
+
+  '@octokit/plugin-throttling@11.0.2':
+    resolution: {integrity: sha512-ntNIig4zZhQVOZF4fG9Wt8QCoz9ehb+xnlUwp74Ic2ANChCk8oKmRwV9zDDCtrvU1aERIOvtng8wsalEX7Jk5Q==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': ^7.0.0
+
+  '@octokit/request-error@7.0.1':
+    resolution: {integrity: sha512-CZpFwV4+1uBrxu7Cw8E5NCXDWFNf18MSY23TdxCBgjw1tXXHvTrZVsXlW8hgFTOLw8RQR1BBrMvYRtuyaijHMA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.5':
+    resolution: {integrity: sha512-TXnouHIYLtgDhKo+N6mXATnDBkV05VwbR0TtMWpgTHIoQdRQfCSzmy/LGqR1AbRMbijq/EckC/E3/ZNcU92NaQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@14.1.0':
+    resolution: {integrity: sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==}
+
+  '@octokit/types@15.0.0':
+    resolution: {integrity: sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==}
+
+  '@octokit/webhooks-methods@6.0.0':
+    resolution: {integrity: sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/webhooks@14.1.3':
+    resolution: {integrity: sha512-gcK4FNaROM9NjA0mvyfXl0KPusk7a1BeA8ITlYEZVQCXF5gcETTd4yhAU0Kjzd8mXwYHppzJBWgdBVpIR9wUcQ==}
+    engines: {node: '>= 20'}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
@@ -3260,6 +3376,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/aws-lambda@8.10.153':
+    resolution: {integrity: sha512-j5zuETAQtPKuU8ZeqtcLdqLxQeNffX1Dd1Sr3tP56rYZD21Ph49iIqWbiHHqwLXugsMPSsgX/bAZI29Patlbbw==}
+
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
@@ -3762,6 +3881,9 @@ packages:
     resolution: {integrity: sha512-L+YvJwGAgwJBV1p6ffpSTa2KRc69EeeYGYjRVWKs0GKrK+LON0GC0gV+rKSNtALEDvMDqkvCFq9r1r94/Gjwxw==}
     hasBin: true
 
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
   better-auth@1.3.11:
     resolution: {integrity: sha512-7l8bHX5rnON4vsVmWB7g2UucNpRlXnDUX/n65mHeR3Zn2/lcpQvfBvGbTaHYU8UGCQadtJ7DLHW/zA3ZR7IfdA==}
     peerDependencies:
@@ -3823,6 +3945,9 @@ packages:
   body-parser@2.2.0:
     resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
     engines: {node: '>=18'}
+
+  bottleneck@2.19.5:
+    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -4852,6 +4977,9 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fast-content-type-parse@3.0.0:
+    resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
 
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
@@ -6183,6 +6311,10 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
+
+  octokit@5.0.3:
+    resolution: {integrity: sha512-+bwYsAIRmYv30NTmBysPIlgH23ekVDriB07oRxlPIAH5PI0yTMSxg5i5Xy0OetcnZw+nk/caD4szD7a9YZ3QyQ==}
+    engines: {node: '>= 20'}
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
@@ -7676,6 +7808,12 @@ packages:
 
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+
+  universal-github-app-jwt@2.2.2:
+    resolution: {integrity: sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==}
+
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -9431,6 +9569,159 @@ snapshots:
     dependencies:
       which: 3.0.1
 
+  '@octokit/app@16.1.1':
+    dependencies:
+      '@octokit/auth-app': 8.1.1
+      '@octokit/auth-unauthenticated': 7.0.2
+      '@octokit/core': 7.0.5
+      '@octokit/oauth-app': 8.0.2
+      '@octokit/plugin-paginate-rest': 13.2.0(@octokit/core@7.0.5)
+      '@octokit/types': 15.0.0
+      '@octokit/webhooks': 14.1.3
+
+  '@octokit/auth-app@8.1.1':
+    dependencies:
+      '@octokit/auth-oauth-app': 9.0.2
+      '@octokit/auth-oauth-user': 6.0.1
+      '@octokit/request': 10.0.5
+      '@octokit/request-error': 7.0.1
+      '@octokit/types': 15.0.0
+      toad-cache: 3.7.0
+      universal-github-app-jwt: 2.2.2
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-app@9.0.2':
+    dependencies:
+      '@octokit/auth-oauth-device': 8.0.2
+      '@octokit/auth-oauth-user': 6.0.1
+      '@octokit/request': 10.0.5
+      '@octokit/types': 15.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-device@8.0.2':
+    dependencies:
+      '@octokit/oauth-methods': 6.0.1
+      '@octokit/request': 10.0.5
+      '@octokit/types': 15.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-user@6.0.1':
+    dependencies:
+      '@octokit/auth-oauth-device': 8.0.2
+      '@octokit/oauth-methods': 6.0.1
+      '@octokit/request': 10.0.5
+      '@octokit/types': 15.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/auth-unauthenticated@7.0.2':
+    dependencies:
+      '@octokit/request-error': 7.0.1
+      '@octokit/types': 15.0.0
+
+  '@octokit/core@7.0.5':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.2
+      '@octokit/request': 10.0.5
+      '@octokit/request-error': 7.0.1
+      '@octokit/types': 15.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.1':
+    dependencies:
+      '@octokit/types': 15.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.2':
+    dependencies:
+      '@octokit/request': 10.0.5
+      '@octokit/types': 15.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/oauth-app@8.0.2':
+    dependencies:
+      '@octokit/auth-oauth-app': 9.0.2
+      '@octokit/auth-oauth-user': 6.0.1
+      '@octokit/auth-unauthenticated': 7.0.2
+      '@octokit/core': 7.0.5
+      '@octokit/oauth-authorization-url': 8.0.0
+      '@octokit/oauth-methods': 6.0.1
+      '@types/aws-lambda': 8.10.153
+      universal-user-agent: 7.0.3
+
+  '@octokit/oauth-authorization-url@8.0.0': {}
+
+  '@octokit/oauth-methods@6.0.1':
+    dependencies:
+      '@octokit/oauth-authorization-url': 8.0.0
+      '@octokit/request': 10.0.5
+      '@octokit/request-error': 7.0.1
+      '@octokit/types': 15.0.0
+
+  '@octokit/openapi-types@25.1.0': {}
+
+  '@octokit/openapi-types@26.0.0': {}
+
+  '@octokit/openapi-webhooks-types@12.0.3': {}
+
+  '@octokit/plugin-paginate-graphql@6.0.0(@octokit/core@7.0.5)':
+    dependencies:
+      '@octokit/core': 7.0.5
+
+  '@octokit/plugin-paginate-rest@13.2.0(@octokit/core@7.0.5)':
+    dependencies:
+      '@octokit/core': 7.0.5
+      '@octokit/types': 15.0.0
+
+  '@octokit/plugin-rest-endpoint-methods@16.1.0(@octokit/core@7.0.5)':
+    dependencies:
+      '@octokit/core': 7.0.5
+      '@octokit/types': 15.0.0
+
+  '@octokit/plugin-retry@8.0.2(@octokit/core@7.0.5)':
+    dependencies:
+      '@octokit/core': 7.0.5
+      '@octokit/request-error': 7.0.1
+      '@octokit/types': 15.0.0
+      bottleneck: 2.19.5
+
+  '@octokit/plugin-throttling@11.0.2(@octokit/core@7.0.5)':
+    dependencies:
+      '@octokit/core': 7.0.5
+      '@octokit/types': 15.0.0
+      bottleneck: 2.19.5
+
+  '@octokit/request-error@7.0.1':
+    dependencies:
+      '@octokit/types': 15.0.0
+
+  '@octokit/request@10.0.5':
+    dependencies:
+      '@octokit/endpoint': 11.0.1
+      '@octokit/request-error': 7.0.1
+      '@octokit/types': 15.0.0
+      fast-content-type-parse: 3.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/types@14.1.0':
+    dependencies:
+      '@octokit/openapi-types': 25.1.0
+
+  '@octokit/types@15.0.0':
+    dependencies:
+      '@octokit/openapi-types': 26.0.0
+
+  '@octokit/webhooks-methods@6.0.0': {}
+
+  '@octokit/webhooks@14.1.3':
+    dependencies:
+      '@octokit/openapi-webhooks-types': 12.0.3
+      '@octokit/request-error': 7.0.1
+      '@octokit/webhooks-methods': 6.0.0
+
   '@opentelemetry/api@1.9.0': {}
 
   '@oxc-project/types@0.93.0': {}
@@ -10965,6 +11256,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/aws-lambda@8.10.153': {}
+
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 24.4.0
@@ -11591,6 +11884,8 @@ snapshots:
 
   baseline-browser-mapping@2.8.4: {}
 
+  before-after-hook@4.0.0: {}
+
   better-auth@1.3.11(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       '@better-auth/utils': 0.3.0
@@ -11673,6 +11968,8 @@ snapshots:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  bottleneck@2.19.5: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -12870,6 +13167,8 @@ snapshots:
       is-extendable: 0.1.1
 
   extend@3.0.2: {}
+
+  fast-content-type-parse@3.0.0: {}
 
   fast-decode-uri-component@1.0.1: {}
 
@@ -14463,6 +14762,20 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  octokit@5.0.3:
+    dependencies:
+      '@octokit/app': 16.1.1
+      '@octokit/core': 7.0.5
+      '@octokit/oauth-app': 8.0.2
+      '@octokit/plugin-paginate-graphql': 6.0.0(@octokit/core@7.0.5)
+      '@octokit/plugin-paginate-rest': 13.2.0(@octokit/core@7.0.5)
+      '@octokit/plugin-rest-endpoint-methods': 16.1.0(@octokit/core@7.0.5)
+      '@octokit/plugin-retry': 8.0.2(@octokit/core@7.0.5)
+      '@octokit/plugin-throttling': 11.0.2(@octokit/core@7.0.5)
+      '@octokit/request-error': 7.0.1
+      '@octokit/types': 14.1.0
+      '@octokit/webhooks': 14.1.3
 
   ohash@2.0.11: {}
 
@@ -16216,6 +16529,10 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
+
+  universal-github-app-jwt@2.2.2: {}
+
+  universal-user-agent@7.0.3: {}
 
   universalify@2.0.1: {}
 


### PR DESCRIPTION
# Current status

Works end-to-end. Needs cleanup.

# Tasks:

- [x] Reuse sandbox setup from `apps/os/backend/sandbox`
- [x] Use a fixed pool of sandbox containers
- [x] Use sandbox sessions for isolation
- [x] Can run shell commands

---

- [x] remove container reuse with sessions (use sessions only for isolation from sandbox code)
- [x] tidy up / deduplicate
- [x] correctly detect if sandbox is running
    - ❗**ISSUES currently: check the comments**
- [x] correctly start it up

---

- [x] exec and return immediately if container is running
- [x] when container boots up, exec and report result
    - ❗**BROKEN currently: check the code**
- [x] use CORE:SET_METADATA for sandboxStatus = starting | attached
    * [x] "context rules" matches this and expands the context for the user

---

- [x] use gh to clone repo
- [x] use gh to list repo contents
- [x] use gh to push to a branch
- [x] use gh to create PR for repo

---

- [ ] load file from sandbox into slack (ephemeral TODO.md)
- [ ] generate image (imagemagick) and load into slack
- [ ] ability to clean the session directory in the sandbox
  * currently persistent for the run of the container
- [ ] correctly handle multiple `exec` state between subsequent commands (e.g. `cd` to a directory)
- [ ] correctly handle multiple `exec` commands in parallel (locking)
- [ ] fix `TODO`s
 
# Potential improvements

- [ ] ensure LLM can do this end-to-end in one go (currently it gets confused):
  1. edit files in the repo,
  2. commit,
  3. push to branch,
  4. and raise a PR (end-to-end)
- [ ] make file editing multi-turn
  * [ ] after each turn load modified file into slack
  * [ ] after each turn ask if we should push to branch + raise a PR

# Research:

- My first attempt at having OpenAI models recognize `local_shell` tool failed (https://x.com/aisdk/status/1973027692942671872)