### PR TITLE
Add bootstrap script for pnpm dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 ## get started
 
 ```bash
+# One-time bootstrap on Ubuntu/Debian
+./scripts/bootstrap-dev.sh
+
+# Manual steps (macOS or if you prefer to manage tools yourself)
 pnpm install
 brew install doppler
 doppler login

--- a/README.md
+++ b/README.md
@@ -106,6 +106,6 @@ You can get them from the slack app settings page.
 
 ## Codex
 
-- Use `scripts/bootstrap-codex-env.sh` to provision the Codex VM tools.
+- `scripts/bootstrap-codex-env.sh` installs repo-specified Node.js/pnpm, runs `pnpm install`, executes `pnpm typecheck`, `pnpm lint`, `pnpm format`, and runs `pnpm test` once Doppler auth is available.
 - Doppler config branch: `dev_codex`.
 - Available to members of the Iterate OpenAI workspace.

--- a/README.md
+++ b/README.md
@@ -101,3 +101,11 @@ SLACK_SIGNING_SECRET
 ```
 
 You can get them from the slack app settings page.
+
+# Coding agents
+
+## Codex
+
+- Use `scripts/bootstrap-codex-env.sh` to provision the Codex VM tools.
+- Doppler config branch: `dev_codex`.
+- Available to members of the Iterate OpenAI workspace.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## get started
 
 ```bash
-# One-time bootstrap on Ubuntu/Debian
-./scripts/bootstrap-dev.sh
+# One-time bootstrap on Ubuntu/Debian (Codex VM environment)
+./scripts/bootstrap-codex-env.sh
 
 # Manual steps (macOS or if you prefer to manage tools yourself)
 pnpm install

--- a/apps/os/backend/agent/slack-agent.ts
+++ b/apps/os/backend/agent/slack-agent.ts
@@ -22,10 +22,7 @@ import {
 } from "./iterate-agent.ts";
 import { slackAgentTools } from "./slack-agent-tools.ts";
 import { slackSlice, type SlackSliceState } from "./slack-slice.ts";
-import {
-  shouldIncludeEventInConversation,
-  shouldUnfurlSlackMessage,
-} from "./slack-agent-utils.ts";
+import { shouldIncludeEventInConversation, shouldUnfurlSlackMessage } from "./slack-agent-utils.ts";
 import type {
   AgentCoreEvent,
   CoreReducedState,

--- a/scripts/bootstrap-codex-env.sh
+++ b/scripts/bootstrap-codex-env.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# This script bootstraps the Iterate monorepo for local development on Ubuntu/Debian systems.
-# It installs Docker (for Postgres and Wrangler containers), Doppler, NVM/Node.js, pnpm,
-# and prepares the workspace dependencies. Re-run the script whenever you need to pick up
-# toolchain updates; it is safe to execute multiple times.
+# This script bootstraps the Iterate monorepo for local development on Codex-provided
+# Ubuntu/Debian systems. It installs Docker (for Postgres and Wrangler containers),
+# Doppler, NVM/Node.js, pnpm, and prepares the workspace dependencies. Re-run the script
+# whenever you need to pick up toolchain updates; it is safe to execute multiple times.
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 

--- a/scripts/bootstrap-codex-env.sh
+++ b/scripts/bootstrap-codex-env.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# This script bootstraps the Iterate monorepo for local development on Codex-provided
-# Ubuntu/Debian systems. It installs Docker (for Postgres and Wrangler containers),
-# Doppler, NVM/Node.js, pnpm, and prepares the workspace dependencies. Re-run the script
-# whenever you need to pick up toolchain updates; it is safe to execute multiple times.
+# This script bootstraps the Iterate monorepo for Codex-provided Ubuntu/Debian
+# environments so that TypeScript type-checking, linting, formatting, and tests
+# succeed. It installs build prerequisites, configures Node.js via nvm using the
+# version tracked in .nvmrc, enables the pnpm version defined in package.json,
+# installs dependencies, and runs the relevant workspace commands.
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 
@@ -28,43 +29,14 @@ sudo apt-get update
 
 log "Installing base dependencies"
 sudo apt-get install -y \
+  build-essential \
   ca-certificates \
   curl \
   gnupg \
   lsb-release \
-  build-essential \
   pkg-config \
-  unzip \
-  tar
-
-log "Ensuring Docker Engine and Compose are installed"
-if ! command -v docker >/dev/null 2>&1; then
-  sudo install -m 0755 -d /etc/apt/keyrings
-  if [[ ! -f /etc/apt/keyrings/docker.gpg ]]; then
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
-      sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-  fi
-  echo \
-"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
-https://download.docker.com/linux/ubuntu \
-$(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-    sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
-  sudo apt-get update
-  sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-else
-  log "Docker already installed; skipping"
-fi
-
-if command -v systemctl >/dev/null 2>&1; then
-  sudo systemctl enable --now docker || true
-else
-  sudo service docker start || true
-fi
-
-if ! id -nG "$USER" | grep -qw docker; then
-  log "Adding $USER to docker group (log out/in to apply)"
-  sudo usermod -aG docker "$USER"
-fi
+  tar \
+  unzip
 
 log "Installing Doppler CLI"
 if ! command -v doppler >/dev/null 2>&1; then
@@ -82,54 +54,48 @@ fi
 source "$NVM_DIR/nvm.sh"
 
 NODE_VERSION="${NODE_VERSION:-}"
-if [[ -z "$NODE_VERSION" ]]; then
-  if [[ -f "$REPO_ROOT/.nvmrc" ]]; then
-    NODE_VERSION="$(tr -d '\r' < "$REPO_ROOT/.nvmrc" | tr -d '\n')"
-  fi
+if [[ -z "$NODE_VERSION" && -f "$REPO_ROOT/.nvmrc" ]]; then
+  NODE_VERSION="$(tr -d '\r\n' < "$REPO_ROOT/.nvmrc")"
 fi
-NODE_VERSION="${NODE_VERSION:-v24.4.1}"
+NODE_VERSION="${NODE_VERSION:-lts/*}"
 log "Using Node.js version $NODE_VERSION"
 nvm install "$NODE_VERSION"
 nvm use "$NODE_VERSION"
 
-log "Enabling pnpm via Corepack"
+log "Configuring pnpm via Corepack"
 corepack enable
 PNPM_VERSION="$(node -p "require('$REPO_ROOT/package.json').packageManager.split('@')[1]")"
-corepack use pnpm@"$PNPM_VERSION"
+corepack prepare pnpm@"$PNPM_VERSION" --activate
 
 log "Installing workspace dependencies"
 cd "$REPO_ROOT"
 pnpm install
 
-log "Starting Postgres via Docker Compose"
-docker compose up -d postgres
+log "Running pnpm typecheck"
+pnpm typecheck
 
-log "Waiting for Postgres to become ready"
-POSTGRES_READY=0
-for attempt in {1..30}; do
-  if docker compose exec -T postgres pg_isready -U postgres -d iterate >/dev/null 2>&1; then
-    POSTGRES_READY=1
-    break
-  fi
-  sleep 2
-done
-if [[ "$POSTGRES_READY" -ne 1 ]]; then
-  echo "Postgres did not become ready in time; check docker logs" >&2
-  exit 1
+log "Running pnpm lint"
+pnpm lint
+
+log "Running pnpm format"
+pnpm format
+
+if doppler me >/dev/null 2>&1; then
+  log "Running pnpm test"
+  pnpm test
+else
+  log "Skipping pnpm test"
+  echo "Doppler authentication is required for 'pnpm test'. Run 'doppler login' and 'doppler setup --project os --config dev_codex'" \
+    "before executing 'pnpm test'."
 fi
 
-log "Running database migrations"
-pnpm db:migrate
-
 cat <<'INSTRUCTIONS'
-
 -------------------------------------------------------------------
 Next steps (manual):
 1. Authenticate with Doppler if you haven't already:
      doppler login
-     doppler setup   # choose project "os" and config "dev_personal"
-2. Configure ngrok if you need Slack/webhook development (see README).
-3. Start the development environment:
+     doppler setup   # choose project "os" and config "dev_personal" or "dev_codex"
+2. Start the development environment when ready:
      pnpm dev
 -------------------------------------------------------------------
 INSTRUCTIONS

--- a/scripts/bootstrap-dev.sh
+++ b/scripts/bootstrap-dev.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script bootstraps the Iterate monorepo for local development on Ubuntu/Debian systems.
+# It installs Docker (for Postgres and Wrangler containers), Doppler, NVM/Node.js, pnpm,
+# and prepares the workspace dependencies. Re-run the script whenever you need to pick up
+# toolchain updates; it is safe to execute multiple times.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+
+log() {
+  printf '\n\033[1;34m>>> %s\033[0m\n' "$1"
+}
+
+require_sudo() {
+  if [[ "$EUID" -ne 0 ]]; then
+    if ! command -v sudo >/dev/null 2>&1; then
+      echo "This script requires sudo privileges to install system packages." >&2
+      echo "Install sudo or run as root and re-run the script." >&2
+      exit 1
+    fi
+  fi
+}
+
+log "Updating apt package lists"
+require_sudo
+sudo apt-get update
+
+log "Installing base dependencies"
+sudo apt-get install -y \
+  ca-certificates \
+  curl \
+  gnupg \
+  lsb-release \
+  build-essential \
+  pkg-config \
+  unzip \
+  tar
+
+log "Ensuring Docker Engine and Compose are installed"
+if ! command -v docker >/dev/null 2>&1; then
+  sudo install -m 0755 -d /etc/apt/keyrings
+  if [[ ! -f /etc/apt/keyrings/docker.gpg ]]; then
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+      sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  fi
+  echo \
+"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+https://download.docker.com/linux/ubuntu \
+$(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+    sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+  sudo apt-get update
+  sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+else
+  log "Docker already installed; skipping"
+fi
+
+if command -v systemctl >/dev/null 2>&1; then
+  sudo systemctl enable --now docker || true
+else
+  sudo service docker start || true
+fi
+
+if ! id -nG "$USER" | grep -qw docker; then
+  log "Adding $USER to docker group (log out/in to apply)"
+  sudo usermod -aG docker "$USER"
+fi
+
+log "Installing Doppler CLI"
+if ! command -v doppler >/dev/null 2>&1; then
+  curl -Ls https://cli.doppler.com/install.sh | sudo sh
+else
+  log "Doppler already installed; skipping"
+fi
+
+log "Installing NVM"
+export NVM_DIR="$HOME/.nvm"
+if [[ ! -s "$NVM_DIR/nvm.sh" ]]; then
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+fi
+# shellcheck disable=SC1090
+source "$NVM_DIR/nvm.sh"
+
+NODE_VERSION="${NODE_VERSION:-}"
+if [[ -z "$NODE_VERSION" ]]; then
+  if [[ -f "$REPO_ROOT/.nvmrc" ]]; then
+    NODE_VERSION="$(tr -d '\r' < "$REPO_ROOT/.nvmrc" | tr -d '\n')"
+  fi
+fi
+NODE_VERSION="${NODE_VERSION:-v24.4.1}"
+log "Using Node.js version $NODE_VERSION"
+nvm install "$NODE_VERSION"
+nvm use "$NODE_VERSION"
+
+log "Enabling pnpm via Corepack"
+corepack enable
+PNPM_VERSION="$(node -p "require('$REPO_ROOT/package.json').packageManager.split('@')[1]")"
+corepack use pnpm@"$PNPM_VERSION"
+
+log "Installing workspace dependencies"
+cd "$REPO_ROOT"
+pnpm install
+
+log "Starting Postgres via Docker Compose"
+docker compose up -d postgres
+
+log "Waiting for Postgres to become ready"
+POSTGRES_READY=0
+for attempt in {1..30}; do
+  if docker compose exec -T postgres pg_isready -U postgres -d iterate >/dev/null 2>&1; then
+    POSTGRES_READY=1
+    break
+  fi
+  sleep 2
+done
+if [[ "$POSTGRES_READY" -ne 1 ]]; then
+  echo "Postgres did not become ready in time; check docker logs" >&2
+  exit 1
+fi
+
+log "Running database migrations"
+pnpm db:migrate
+
+cat <<'INSTRUCTIONS'
+
+-------------------------------------------------------------------
+Next steps (manual):
+1. Authenticate with Doppler if you haven't already:
+     doppler login
+     doppler setup   # choose project "os" and config "dev_personal"
+2. Configure ngrok if you need Slack/webhook development (see README).
+3. Start the development environment:
+     pnpm dev
+-------------------------------------------------------------------
+INSTRUCTIONS
+
+log "Bootstrap complete"


### PR DESCRIPTION
## Summary
- add a Ubuntu/Debian bootstrap script that installs Docker, Doppler, Node via nvm, pnpm, and prepares the workspace
- wait for Postgres to become ready and run database migrations automatically after bringing up the Docker container
- document the new bootstrap flow in the README so developers can provision the environment with one command

## Testing
- pnpm install

------
https://chatgpt.com/codex/tasks/task_b_68de49b103148333b8d76e8fa8f8eee7