### PR TITLE
feat: add slack web client wrapper

### DIFF
--- a/apps/os/backend/agent/slack-agent.ts
+++ b/apps/os/backend/agent/slack-agent.ts
@@ -1,5 +1,5 @@
 import type { SlackEvent } from "@slack/types";
-import { WebClient } from "@slack/web-api";
+import type { WebClient } from "@slack/web-api";
 import { and, asc, eq, or, inArray } from "drizzle-orm";
 import pDebounce from "p-suite/p-debounce";
 import { waitUntil } from "cloudflare:workers";
@@ -8,6 +8,7 @@ import { logger as console } from "../tag-logger.ts";
 import { getSlackAccessTokenForEstate } from "../auth/token-utils.ts";
 import { slackWebhookEvent, providerUserMapping } from "../db/schema.ts";
 import { getFileContent, uploadFileFromURL } from "../file-handlers.ts";
+import { createSlackWebClient } from "../integrations/slack/slack-web-client.ts";
 import type {
   AgentCoreDeps,
   AgentCoreEventInput,
@@ -119,7 +120,7 @@ export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsI
       throw new Error(`Slack access token not set for estate ${params.record.estateId}.`);
     }
     // For now we want to make errors maximally visible
-    this.slackAPI = new WebClient(slackAccessToken, {
+    this.slackAPI = createSlackWebClient(slackAccessToken, {
       rejectRateLimitedCalls: true,
       retryConfig: { retries: 0 },
     });

--- a/apps/os/backend/auth/integrations.ts
+++ b/apps/os/backend/auth/integrations.ts
@@ -7,7 +7,6 @@ import { z } from "zod";
 import { generateRandomString } from "better-auth/crypto";
 import { getContext } from "hono/context-storage";
 import { eq, and } from "drizzle-orm";
-import { WebClient } from "@slack/web-api";
 import { waitUntil } from "cloudflare:workers";
 import { logger as console } from "../tag-logger.ts";
 import type { Variables } from "../worker";
@@ -16,6 +15,7 @@ import { env, type CloudflareEnv } from "../../env.ts";
 import { IterateAgent } from "../agent/iterate-agent.ts";
 import { SlackAgent } from "../agent/slack-agent.ts";
 import { syncSlackUsersInBackground } from "../integrations/slack/slack.ts";
+import { createSlackWebClient } from "../integrations/slack/slack-web-client.ts";
 import { MCPOAuthState, SlackBotOAuthState } from "./oauth-state-schemas.ts";
 
 export const SLACK_BOT_SCOPES = [
@@ -335,7 +335,7 @@ export const integrationsPlugin = () =>
 
           const redirectURI = `${env.VITE_PUBLIC_URL}/api/auth/integrations/callback/slack-bot`;
 
-          const unauthedSlackClient = new WebClient();
+          const unauthedSlackClient = createSlackWebClient();
 
           const tokens = await unauthedSlackClient.oauth.v2.access({
             client_id: env.SLACK_CLIENT_ID,
@@ -358,7 +358,7 @@ export const integrationsPlugin = () =>
             return ctx.json({ error: "Failed to get tokens" });
           }
 
-          const userSlackClient = new WebClient(tokens.authed_user.access_token);
+          const userSlackClient = createSlackWebClient(tokens.authed_user.access_token);
 
           const userInfo = await userSlackClient.users.identity({});
 

--- a/apps/os/backend/integrations/slack/slack-web-client.ts
+++ b/apps/os/backend/integrations/slack/slack-web-client.ts
@@ -1,4 +1,4 @@
-import { ErrorCode, WebClient, type WebClientOptions } from "@slack/web-api";
+import { WebClient, type WebClientOptions } from "@slack/web-api";
 import type { WebAPICallResult } from "@slack/web-api/dist/WebClient";
 import dedent from "dedent";
 

--- a/apps/os/backend/integrations/slack/slack-web-client.ts
+++ b/apps/os/backend/integrations/slack/slack-web-client.ts
@@ -1,0 +1,55 @@
+import { ErrorCode, WebClient, type WebClientOptions } from "@slack/web-api";
+import type { WebAPICallResult } from "@slack/web-api/dist/WebClient";
+
+type SlackHttpError = Error & {
+  code?: string;
+  statusCode?: number;
+};
+
+const isSlackHttpError = (error: unknown): error is SlackHttpError => {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const candidate = error as SlackHttpError;
+
+  if (candidate.code === ErrorCode.HTTPError) {
+    return true;
+  }
+
+  return typeof candidate.statusCode === "number" && candidate.statusCode !== 200;
+};
+
+class ThrowingSlackWebClient extends WebClient {
+  override async apiCall(
+    method: string,
+    options: Record<string, unknown> = {},
+  ): Promise<WebAPICallResult> {
+    try {
+      const result = await super.apiCall(method, options);
+
+      if ("ok" in result && result.ok === false) {
+        throw new Error(`Slack API call to ${method} failed: ${result.error ?? "unknown_error"}`);
+      }
+
+      return result;
+    } catch (error) {
+      if (isSlackHttpError(error)) {
+        const statusMessage =
+          error.statusCode !== undefined
+            ? `HTTP status ${error.statusCode}`
+            : "a non-200 HTTP response";
+
+        throw new Error(`Slack API call to ${method} failed with ${statusMessage}`, {
+          cause: error,
+        });
+      }
+
+      throw error;
+    }
+  }
+}
+
+export const createSlackWebClient = (token?: string, options?: WebClientOptions): WebClient => {
+  return new ThrowingSlackWebClient(token, options);
+};

--- a/apps/os/backend/integrations/slack/slack-web-client.ts
+++ b/apps/os/backend/integrations/slack/slack-web-client.ts
@@ -1,52 +1,21 @@
 import { ErrorCode, WebClient, type WebClientOptions } from "@slack/web-api";
 import type { WebAPICallResult } from "@slack/web-api/dist/WebClient";
-
-type SlackHttpError = Error & {
-  code?: string;
-  statusCode?: number;
-};
-
-const isSlackHttpError = (error: unknown): error is SlackHttpError => {
-  if (!error || typeof error !== "object") {
-    return false;
-  }
-
-  const candidate = error as SlackHttpError;
-
-  if (candidate.code === ErrorCode.HTTPError) {
-    return true;
-  }
-
-  return typeof candidate.statusCode === "number" && candidate.statusCode !== 200;
-};
+import dedent from "dedent";
 
 class ThrowingSlackWebClient extends WebClient {
   override async apiCall(
     method: string,
     options: Record<string, unknown> = {},
   ): Promise<WebAPICallResult> {
-    try {
-      const result = await super.apiCall(method, options);
-
-      if ("ok" in result && result.ok === false) {
-        throw new Error(`Slack API call to ${method} failed: ${result.error ?? "unknown_error"}`);
-      }
-
-      return result;
-    } catch (error) {
-      if (isSlackHttpError(error)) {
-        const statusMessage =
-          error.statusCode !== undefined
-            ? `HTTP status ${error.statusCode}`
-            : "a non-200 HTTP response";
-
-        throw new Error(`Slack API call to ${method} failed with ${statusMessage}`, {
-          cause: error,
-        });
-      }
-
-      throw error;
+    const result = await super.apiCall(method, options);
+    if ("ok" in result && result.ok === false) {
+      throw new Error(dedent`
+        Slack API call to ${method} failed: ${result.error ?? "unknown_error"}
+        Options: ${JSON.stringify(options, null, 2)}
+        Response metadata: ${JSON.stringify(result.response_metadata, null, 2)}
+      `);
     }
+    return result;
   }
 }
 

--- a/apps/os/backend/integrations/slack/slack.ts
+++ b/apps/os/backend/integrations/slack/slack.ts
@@ -2,6 +2,7 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import { Hono } from "hono";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import { type ConversationsRepliesResponse } from "@slack/web-api";
+import type { WebClient } from "@slack/web-api";
 import { waitUntil } from "cloudflare:workers";
 import * as R from "remeda";
 import { type CloudflareEnv } from "../../../env.ts";
@@ -224,7 +225,7 @@ export async function reactToSlackWebhook(
           })
           .then(
             () => console.log("[SlackAgent] Added eyes reaction"),
-            (error) => console.error("[SlackAgent] Failed to add eyes reaction", error),
+            (error: unknown) => console.error("[SlackAgent] Failed to add eyes reaction", error),
           );
       }
     }

--- a/apps/os/backend/trpc/routers/integrations.ts
+++ b/apps/os/backend/trpc/routers/integrations.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 import { eq, and, inArray, sql } from "drizzle-orm";
 import { generateRandomString } from "better-auth/crypto";
 import { TRPCError } from "@trpc/server";
-import { WebClient } from "@slack/web-api";
 import { estateProtectedProcedure, router } from "../trpc.ts";
 import { account, organizationUserMembership, estateAccountsPermissions } from "../../db/schema.ts";
 import * as schemas from "../../db/schema.ts";
@@ -21,6 +20,7 @@ import {
   getSlackAccessTokenForEstate,
 } from "../../auth/token-utils.ts";
 import { getRoutingKey } from "../../integrations/slack/slack.ts";
+import { createSlackWebClient } from "../../integrations/slack/slack-web-client.ts";
 
 // Define the integration providers we support
 const INTEGRATION_PROVIDERS = {
@@ -832,7 +832,7 @@ export const integrationsRouter = router({
         });
       }
 
-      const slackAPI = new WebClient(accessToken);
+      const slackAPI = createSlackWebClient(accessToken);
 
       const chatResult = await slackAPI.chat.postMessage({
         channel: channel,
@@ -884,7 +884,7 @@ export const integrationsRouter = router({
         });
       }
 
-      const slackAPI = new WebClient(accessToken);
+      const slackAPI = createSlackWebClient(accessToken);
       const result = await slackAPI.conversations.list({
         types: types,
         exclude_archived: excludeArchived,


### PR DESCRIPTION
- add a reusable Slack WebClient factory that surfaces non-200 HTTP responses as errors
- update backend Slack integrations to construct clients through the wrapper to ensure consistent error handling

Until we're all-in on effect or something, I prefer this, because it means failed slack API calls come to our attention. At the moment they are just quietly dropped in a few places