### PR TITLE
import logger as logger

### DIFF
--- a/apps/os/backend/agent/context.ts
+++ b/apps/os/backend/agent/context.ts
@@ -3,7 +3,7 @@ import { readFileSync, accessSync } from "fs";
 import { fileURLToPath } from "url";
 import { globSync } from "glob";
 import jsonataLib from "jsonata/sync";
-import { logger as console } from "../tag-logger.ts";
+import { logger } from "../tag-logger.ts";
 import type {
   ContextRule,
   ContextRuleMatcher,
@@ -362,7 +362,7 @@ export function contextRulesFromFiles(pattern: string, overrides: Partial<Contex
       });
     });
   } catch (error) {
-    console.error(`Error reading files with pattern ${pattern}:`, error);
+    logger.error(`Error reading files with pattern ${pattern}:`, error);
     return [];
   }
 }

--- a/apps/os/backend/agent/iterate-agent.ts
+++ b/apps/os/backend/agent/iterate-agent.ts
@@ -8,7 +8,7 @@ import { and, eq } from "drizzle-orm";
 import * as R from "remeda";
 import { waitUntil } from "cloudflare:workers";
 import Replicate from "replicate";
-import { logger as console } from "../tag-logger.ts";
+import { logger } from "../tag-logger.ts";
 import { env, type CloudflareEnv } from "../../env.ts";
 import { getDb, schema, type DB } from "../db/client.ts";
 import { PosthogCloudflare } from "../utils/posthog-cloudflare.ts";
@@ -171,7 +171,7 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
       .fetch(req)
       .then((res) => res.text())
       .catch((e) => {
-        console.error("Could not set server name:", e);
+        logger.error("Could not set server name:", e);
       });
 
     return stub;
@@ -457,7 +457,7 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
             }),
           );
         } catch (error) {
-          console.warn("Failed to broadcast events:", error);
+          logger.warn("Failed to broadcast events:", error);
         }
       },
 
@@ -711,7 +711,7 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
     // sadly drizzle doesn't support abort signals yet https://github.com/drizzle-team/drizzle-orm/issues/1602
     // const rulesFromDb = await pTimeout(IterateAgent.getRulesFromDB(db, databaseRecord.estateId), {
     //   milliseconds: 250,
-    //   fallback: () => console.warn("getRulesFromDB timeout - DO initialisation deadlock?"),
+    //   fallback: () => logger.warn("getRulesFromDB timeout - DO initialisation deadlock?"),
     // });
     const rules = [
       ...defaultContextRules,
@@ -787,11 +787,11 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
    * Generic handler for scheduled reminders. This method will be called by the scheduler.
    */
   async handleReminder(data: { iterateReminderId: string }) {
-    console.info(`Executing reminder: ${data.iterateReminderId}`);
+    logger.info(`Executing reminder: ${data.iterateReminderId}`);
 
     const reminder = this.state.reminders?.[data.iterateReminderId];
     if (!reminder) {
-      console.error(`Reminder with ID ${data.iterateReminderId} not found in state.`);
+      logger.error(`Reminder with ID ${data.iterateReminderId} not found in state.`);
       return;
     }
 
@@ -1232,7 +1232,7 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
       !Array.isArray(replicateResponse) ||
       !replicateResponse.every((url) => typeof url === "string" && url.startsWith("https://"))
     ) {
-      console.warn(
+      logger.warn(
         "Replicate API returned non-array response or array contains non-string values",
         replicateResponse,
       );

--- a/apps/os/backend/agent/json-schema.ts
+++ b/apps/os/backend/agent/json-schema.ts
@@ -1,7 +1,7 @@
 import { prettifyError, z } from "zod/v4";
 import type { AnyProcedure, AnyTRPCRouter } from "@trpc/server";
 import { constructMergeSchema } from "../utils/schema-helpers.ts";
-import { logger as console } from "../tag-logger.ts";
+import { logger } from "../tag-logger.ts";
 import type { RuntimeJsonSchema } from "./do-tools.ts";
 
 export type DurableObjectClass<T = any> = new (ctx: DurableObjectState, env: any) => T;
@@ -13,7 +13,7 @@ const createFallbackJsonSchema = () => {
       target: "draft-2020-12",
     });
   } catch (error) {
-    console.error("Failed to create fallback JSON schema:", error);
+    logger.error("Failed to create fallback JSON schema:", error);
     // Ultimate fallback if even the empty object schema fails
     return { type: "object", additionalProperties: true };
   }
@@ -28,7 +28,7 @@ export const convertTrpcRouterToRuntimeJsonSchema = (router: AnyTRPCRouter) => {
           const schema = procedureToJSONSchema(router, p);
           return [p, schema];
         } catch (error) {
-          console.error(`Failed to generate JSON schema for TRPC procedure ${p}:`, error);
+          logger.error(`Failed to generate JSON schema for TRPC procedure ${p}:`, error);
           // Create a fallback runtime schema
           const fallbackJsonSchema = createFallbackJsonSchema();
           return [

--- a/apps/os/backend/agent/mcp/mcp-event-hooks.ts
+++ b/apps/os/backend/agent/mcp/mcp-event-hooks.ts
@@ -3,7 +3,7 @@ import PQueue from "p-queue";
 import { eq, and } from "drizzle-orm";
 import * as R from "remeda";
 import { exhaustiveMatchingGuard, type Branded, type Result } from "../../utils/type-helpers.ts";
-import { logger as console } from "../../tag-logger.ts";
+import { logger } from "../../tag-logger.ts";
 import type { MergedStateForSlices } from "../agent-core.ts";
 import type { CoreAgentSlices } from "../iterate-agent.ts";
 import type { AgentDurableObjectInfo } from "../../auth/oauth-state-schemas.ts";
@@ -330,7 +330,7 @@ export async function handleMCPConnectRequest(
   const prompts = manager.listPrompts().filter((p) => p.serverId === result.id);
   const resources = manager.listResources().filter((r) => r.serverId === result.id);
 
-  console.log(
+  logger.log(
     `[MCP] Server ${result.id} provides ${tools.length} tools, ${prompts.length} prompts, ${resources.length} resources`,
   );
 
@@ -406,12 +406,12 @@ async function handleMCPDisconnectRequest(
           if (entry && entry.queue.size === 0 && entry.queue.pending === 0) {
             connectionQueues.delete(cacheKey);
           }
-          console.log(`[MCP] Disconnected and removed manager for ${key}`);
+          logger.log(`[MCP] Disconnected and removed manager for ${key}`);
         } else {
-          console.warn(`[MCP] No manager found for connection ${key}`);
+          logger.warn(`[MCP] No manager found for connection ${key}`);
         }
       } catch (error) {
-        console.warn(`[MCP] Failed to disconnect ${key}:`, error);
+        logger.warn(`[MCP] Failed to disconnect ${key}:`, error);
       }
     }
   }

--- a/apps/os/backend/agent/mcp/mcp-oauth-provider.ts
+++ b/apps/os/backend/agent/mcp/mcp-oauth-provider.ts
@@ -2,7 +2,7 @@ import type { AgentsOAuthProvider } from "agents/mcp/do-oauth-client-provider";
 import { eq, and } from "drizzle-orm";
 import { z } from "zod";
 import { generateRandomString } from "better-auth/crypto";
-import { logger as console } from "../../tag-logger.ts";
+import { logger } from "../../tag-logger.ts";
 import type { Auth } from "../../auth/auth.ts";
 import type { DB } from "../../db/client.ts";
 import * as schema from "../../db/schema.ts";
@@ -128,7 +128,7 @@ export class MCPOAuthProvider implements AgentsOAuthProvider {
 
     const clientInfo = DynamicClientInfo.safeParse(dynamicClientInfo.clientInfo);
     if (!clientInfo.success) {
-      console.error(`Failed to parse client information: ${z.prettifyError(clientInfo.error)}`);
+      logger.error(`Failed to parse client information: ${z.prettifyError(clientInfo.error)}`);
       return undefined;
     }
     return clientInfo.data;

--- a/apps/os/backend/agent/mcp/mcp-tool-mapping.ts
+++ b/apps/os/backend/agent/mcp/mcp-tool-mapping.ts
@@ -6,7 +6,7 @@ import { sanitizeToolName } from "../tool-spec-to-runtime-tool.ts";
 import { IntegrationMode } from "../tool-schemas.ts";
 import type { CoreAgentSlices } from "../iterate-agent.ts";
 import type { AgentDurableObjectInfo } from "../../auth/oauth-state-schemas.ts";
-import { logger as console } from "../../tag-logger.ts";
+import { logger } from "../../tag-logger.ts";
 import {
   rehydrateExistingMCPConnection,
   mcpManagerCache,
@@ -197,7 +197,7 @@ export async function processMCPContent(
           filename,
         });
       } catch (error) {
-        console.error(`[MCP] Failed to upload ${contentItem.type} content:`, error);
+        logger.error(`[MCP] Failed to upload ${contentItem.type} content:`, error);
         // Add to processed content without data field as fallback
         const { data: _data, ...itemWithoutData } = contentItem;
         processedContent.push({
@@ -291,7 +291,7 @@ function hasToolSchemaConflicts(
   );
 
   if (hasConflict) {
-    console.error(`[MCP] Schema conflict detected for tool ${toolName}. Skipping tool creation.`);
+    logger.error(`[MCP] Schema conflict detected for tool ${toolName}. Skipping tool creation.`);
   }
 
   return hasConflict;
@@ -453,9 +453,7 @@ export function createRuntimeToolFromMCPTool(params: {
           );
         }
 
-        console.log(
-          `[MCP] Tool ${toolName} triggering lazy connection to ${selectedConnectionKey}`,
-        );
+        logger.log(`[MCP] Tool ${toolName} triggering lazy connection to ${selectedConnectionKey}`);
 
         const result = await rehydrateExistingMCPConnection({
           connectionKey: selectedConnectionKey,
@@ -505,7 +503,7 @@ export function createRuntimeToolFromMCPTool(params: {
           arguments: toolArgs,
         })
         .catch((error) => {
-          console.error(
+          logger.error(
             `[MCP] Tool execution failed for ${tool.name}:`,
             (error as Error)?.stack || error,
           );
@@ -546,7 +544,7 @@ export function createRuntimeToolFromMCPTool(params: {
             addEvents: [...additionalMCPEvents, ...fileEvents],
           };
         } catch (error) {
-          console.warn(`Failed to fetch resource ${mcpResult.resource_link}:`, error);
+          logger.warn(`Failed to fetch resource ${mcpResult.resource_link}:`, error);
         }
       }
 

--- a/apps/os/backend/agent/openai-responses-api-docs-playground.ts
+++ b/apps/os/backend/agent/openai-responses-api-docs-playground.ts
@@ -32,7 +32,7 @@ import type {
 import { OpenAI } from "openai";
 
 import type { Prettify } from "ts-essentials";
-import { logger as console } from "../tag-logger.ts";
+import { logger } from "../tag-logger.ts";
 
 // Create prettified type aliases for better hover experience
 export type ResponseCreateParamsPretty = Prettify<ResponseCreateParams>;
@@ -71,7 +71,7 @@ async function _consumeStream() {
       outputItems[ev.output_index] = ev.item; // collect finalized item
     }
     if (ev.type === "response.completed") {
-      console.log("All items final:", outputItems);
+      logger.log("All items final:", outputItems);
     }
   }
 }
@@ -391,7 +391,7 @@ const _functionResultFromYou: ResponseInputItem.FunctionCallOutput = {
      ],
      tools: [{ type: "function", name: "myCalculator", parameters:{ type: "object" } }]
    });
-   console.log(res.output); // If not streaming
+   logger.log(res.output); // If not streaming
 ------------------------------------------------------------------------------------------------- */
 
 /*

--- a/apps/os/backend/agent/posthog-openai-wrapper.ts
+++ b/apps/os/backend/agent/posthog-openai-wrapper.ts
@@ -1,7 +1,7 @@
 import type OpenAI from "openai";
 import { SELF_AGENT_DISTINCT_ID, type PosthogCloudflare } from "../utils/posthog-cloudflare.ts";
 import { formatItemsForObservability } from "../utils/observability-formatter.ts";
-import { logger as console } from "../tag-logger.ts";
+import { logger } from "../tag-logger.ts";
 
 // Global trace storage for conversation continuity
 const _traceStorage = new Map<
@@ -128,7 +128,7 @@ export function posthogOpenAIWrapper(
                 const { model, metadata, usage, output } = await res.finalResponse();
 
                 if (process.env.DEBUG_POSTHOG) {
-                  console.log(`[PostHog] Logging trace ${traceId}: ${output.length} messages`);
+                  logger.log(`[PostHog] Logging trace ${traceId}: ${output.length} messages`);
                 }
 
                 sendPostHogGenerationEventWithFullData({

--- a/apps/os/backend/agent/schema-utils.ts
+++ b/apps/os/backend/agent/schema-utils.ts
@@ -4,7 +4,7 @@ import { type Schema, Validator } from "@cfworker/json-schema";
 import type z from "zod/v4";
 import { toJSONSchema, type ZodType } from "zod/v4";
 import type { JSONSchema } from "zod/v4/core";
-import { logger as console } from "../tag-logger.ts";
+import { logger } from "../tag-logger.ts";
 
 // Backward compatibility - alias BaseJSONSchema to JSONSchema.JSONSchema
 export type BaseJSONSchema = JSONSchema.JSONSchema;
@@ -115,7 +115,7 @@ function mapZodJsonToCFWorkerSchema(
   }
 
   // Log a warning or throw an error for unexpected result types.
-  console.warn(
+  logger.warn(
     "mapZodJsonToCFWorkerSchema encountered an unexpected result type after recursion:",
     typeof mappedSchema,
   );

--- a/apps/os/backend/agent/slack-agent-utils.ts
+++ b/apps/os/backend/agent/slack-agent-utils.ts
@@ -3,7 +3,7 @@ import type { SlackEvent } from "@slack/types";
 import { eq, asc } from "drizzle-orm";
 import type { DB } from "../db/client.ts";
 import { slackWebhookEvent } from "../db/schema.ts";
-import { logger as console } from "../tag-logger.ts";
+import { logger } from "../tag-logger.ts";
 import type { SlackWebhookPayload } from "./slack.types";
 
 export function getMentionedExternalUserIds(body: string) {
@@ -409,7 +409,7 @@ export function shouldIncludeEventInConversation(
       // TypeScript's exhaustive check - if this line has an error, it means
       // there are unhandled event types that should be explicitly handled above
       const unhandledEvent: SlackEvent = slackEvent;
-      console.warn(`Unhandled Slack event type: ${unhandledEvent.type}`);
+      logger.warn(`Unhandled Slack event type: ${unhandledEvent.type}`);
 
       // For now, ignore any unhandled event types
       // When new event types are added to @slack/types, they'll appear here

--- a/apps/os/backend/agent/slack-agent.ts
+++ b/apps/os/backend/agent/slack-agent.ts
@@ -4,7 +4,7 @@ import { and, asc, eq, or, inArray } from "drizzle-orm";
 import pDebounce from "p-suite/p-debounce";
 import { waitUntil } from "cloudflare:workers";
 import { env as _env, env } from "../../env.ts";
-import { logger as console } from "../tag-logger.ts";
+import { logger } from "../tag-logger.ts";
 import { getSlackAccessTokenForEstate } from "../auth/token-utils.ts";
 import { slackWebhookEvent, providerUserMapping } from "../db/schema.ts";
 import { getFileContent, uploadFileFromURL } from "../file-handlers.ts";
@@ -167,7 +167,7 @@ export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsI
             ]);
             break;
           case "CORE:INTERNAL_ERROR": {
-            console.error("[SlackAgent] Internal Error:", payload.event);
+            logger.error("[SlackAgent] Internal Error:", payload.event);
             const errorEvent = payload.event as AgentCoreEvent & { type: "CORE:INTERNAL_ERROR" };
             const errorMessage = errorEvent.data?.error || "Unknown error";
             waitUntil(
@@ -210,7 +210,7 @@ export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsI
           try {
             const downloadUrl = slackFile.url_private_download || slackFile.url_private;
             if (!downloadUrl) {
-              console.error(`No download URL for Slack file ${slackFile.id}`);
+              logger.error(`No download URL for Slack file ${slackFile.id}`);
               return null;
             }
             const fileRecord = await uploadFileFromURL({
@@ -222,7 +222,7 @@ export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsI
                 Authorization: `Bearer ${this.slackAPI.token}`,
               },
             });
-            console.log("File record", fileRecord);
+            logger.log("File record", fileRecord);
             return {
               iterateFileId: fileRecord.id,
               originalFilename: fileRecord.filename ?? undefined,
@@ -232,7 +232,7 @@ export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsI
               slackFileId: slackFile.id,
             };
           } catch (error) {
-            console.error(`Failed to upload Slack file ${slackFile.id}:`, error);
+            logger.error(`Failed to upload Slack file ${slackFile.id}:`, error);
             return null;
           }
         });
@@ -526,7 +526,7 @@ export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsI
           return result.permalink;
         }
       } catch (error) {
-        console.error("Failed to get Slack permalink:", error);
+        logger.error("Failed to get Slack permalink:", error);
       }
     } else {
       // if we can't find any message, get link to the thread
@@ -534,7 +534,7 @@ export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsI
       const threadTs = state.reducedState?.slackThreadId;
 
       if (!channelId || !threadTs) {
-        console.error("Channel ID and thread TS are required to get a Slack permalink", {
+        logger.error("Channel ID and thread TS are required to get a Slack permalink", {
           channelId,
           threadTs,
         });
@@ -549,7 +549,7 @@ export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsI
           return result.permalink;
         }
       } catch (error) {
-        console.error("Failed to get Slack permalink:", error);
+        logger.error("Failed to get Slack permalink:", error);
       }
     }
     return undefined;
@@ -787,8 +787,8 @@ export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsI
 
       return completeResponse;
     } catch (error) {
-      console.warn("[SlackAgent] Failed uploading file:", error);
-      console.log("Full error details:", JSON.stringify(error, null, 2));
+      logger.warn("[SlackAgent] Failed uploading file:", error);
+      logger.log("Full error details:", JSON.stringify(error, null, 2));
       return {
         success: false,
         error: error instanceof Error ? error.message : "Unknown error",
@@ -816,7 +816,7 @@ export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsI
         });
       }
     } catch (error) {
-      console.warn("[SlackAgent] Failed adding zipper-mouth reaction:", error);
+      logger.warn("[SlackAgent] Failed adding zipper-mouth reaction:", error);
     }
     return {
       __pauseAgentUntilMentioned: true,

--- a/apps/os/backend/agent/zod-to-openai-json-schema.ts
+++ b/apps/os/backend/agent/zod-to-openai-json-schema.ts
@@ -9,7 +9,7 @@ import {
   type ZodType,
   type ZodUnion,
 } from "zod/v4";
-import { logger as console } from "../tag-logger.ts";
+import { logger } from "../tag-logger.ts";
 import type { BaseJSONSchema, SchemaBranded } from "./schema-utils.ts";
 
 const keysToStrip = ["workflowCallbackTarget"];
@@ -46,7 +46,7 @@ export function zodToOpenAIJSONSchema<
       JSON.stringify(
         toJSONSchema(zodSchema, {
           override: (ctx) => {
-            console.log("ctx.jsonSchema", ctx.jsonSchema);
+            logger.log("ctx.jsonSchema", ctx.jsonSchema);
             makeJSONSchemaOpenAICompatible(ctx.jsonSchema);
           },
           unrepresentable: "any",
@@ -93,8 +93,8 @@ export function zodToOpenAIJSONSchema<
       ).replaceAll('{"not":{}}', "false"),
     ) as SchemaBranded<BaseJSONSchema, T>;
   } catch (e) {
-    console.log(zodSchema);
-    console.error("Error converting zod schema to openai json schema", e);
+    logger.log(zodSchema);
+    logger.error("Error converting zod schema to openai json schema", e);
     throw e;
   }
 }

--- a/apps/os/backend/auth/auth.ts
+++ b/apps/os/backend/auth/auth.ts
@@ -5,7 +5,7 @@ import { typeid } from "typeid-js";
 import { type DB } from "../db/client.ts";
 import * as schema from "../db/schema.ts";
 import { env } from "../../env.ts";
-import { logger as console } from "../tag-logger.ts";
+import { logger } from "../tag-logger.ts";
 import { integrationsPlugin } from "./integrations.ts";
 import { createUserOrganizationAndEstate } from "./hooks.ts";
 
@@ -57,8 +57,8 @@ export const getAuth = (db: DB) =>
         create: {
           after: async (user) => {
             await createUserOrganizationAndEstate(db, user.id, user.name).catch((error) => {
-              console.error(error);
-              console.error("❌ Error creating organization and estate", user);
+              logger.error(error);
+              logger.error("❌ Error creating organization and estate", user);
             });
           },
         },

--- a/apps/os/backend/auth/hooks.ts
+++ b/apps/os/backend/auth/hooks.ts
@@ -3,7 +3,7 @@ import dedent from "dedent";
 import type { DB } from "../db/client.ts";
 import * as schema from "../db/schema.ts";
 import { env } from "../../env.ts";
-import { logger as console } from "../tag-logger.ts";
+import { logger } from "../tag-logger.ts";
 import { sendNotificationToIterateSlack } from "../integrations/slack/slack-utils.ts";
 
 // Function to create organization and estate for new users
@@ -57,7 +57,7 @@ export const createUserOrganizationAndEstate = async (db: DB, userId: string, us
     if (env.ITERATE_NOTIFICATION_ESTATE_ID) {
       waitUntil(
         sendEstateCreatedNotificationToSlack(result.organization, result.estate).catch((error) => {
-          console.error("Failed to send Slack notification for new estate", error);
+          logger.error("Failed to send Slack notification for new estate", error);
         }),
       );
     }

--- a/apps/os/backend/auth/integrations.ts
+++ b/apps/os/backend/auth/integrations.ts
@@ -9,7 +9,7 @@ import { getContext } from "hono/context-storage";
 import { eq, and } from "drizzle-orm";
 import { WebClient } from "@slack/web-api";
 import { waitUntil } from "cloudflare:workers";
-import { logger as console } from "../tag-logger.ts";
+import { logger } from "../tag-logger.ts";
 import type { Variables } from "../worker";
 import * as schema from "../db/schema.ts";
 import { env, type CloudflareEnv } from "../../env.ts";
@@ -125,7 +125,7 @@ export const integrationsPlugin = () =>
           const estateWithMembership = result[0]?.estate;
 
           if (!estateWithMembership) {
-            console.error("Estate not found or user not authorized", {
+            logger.error("Estate not found or user not authorized", {
               estateId: state.estateId,
               userId: state.userId,
             });

--- a/apps/os/backend/default-tools.ts
+++ b/apps/os/backend/default-tools.ts
@@ -6,7 +6,7 @@ import type { AgentCoreEventInput } from "./agent/agent-core-schemas.ts";
 import type { DB } from "./db/client.ts";
 import { slackWebhookEvent } from "./db/schema.ts";
 import { uploadFile } from "./file-handlers.ts";
-import { logger as console } from "./tag-logger.ts";
+import { logger } from "./tag-logger.ts";
 
 const ContentsOptions = z.object({
   text: z
@@ -499,7 +499,7 @@ async function getURLContentFromSlack(params: { url: string; db: DB }) {
       slackChannelId: channelId,
     };
   } catch (error) {
-    console.error("Failed to fetch Slack thread content:", error);
+    logger.error("Failed to fetch Slack thread content:", error);
     return {
       success: false,
       error: `Failed to fetch Slack thread content: ${error instanceof Error ? error.message : "Unknown error"}`,
@@ -537,7 +537,7 @@ async function getURLContentFromWebpage(params: {
   const exaResult = includeTextContent && isFulfilled(textResult) ? textResult.value : null;
 
   if (includeTextContent && !isFulfilled(textResult)) {
-    console.error("Exa link contents failed:", textResult.reason);
+    logger.error("Exa link contents failed:", textResult.reason);
     if (!includeScreenshotOfPage || !isFulfilled(screenshotResult)) {
       return {
         success: false,
@@ -583,10 +583,10 @@ async function getURLContentFromWebpage(params: {
         });
         screenshotTaken = true;
       } else if (screenshotPayload?.type === "text" && "text" in screenshotPayload) {
-        console.error("Screenshot failed:", screenshotPayload.text);
+        logger.error("Screenshot failed:", screenshotPayload.text);
       }
     } else {
-      console.error("Screenshot API call failed:", screenshotResult.reason);
+      logger.error("Screenshot API call failed:", screenshotResult.reason);
     }
   }
 
@@ -634,7 +634,7 @@ async function getURLContentFromFile(params: {
     contentType: contentType || "application/octet-stream",
   });
 
-  console.log(`File uploaded for ${url}: ${fileRecord.id}`);
+  logger.log(`File uploaded for ${url}: ${fileRecord.id}`);
 
   const additionalEvents: AgentCoreEventInput[] = [
     {

--- a/apps/os/backend/durable-objects/organization-websocket.ts
+++ b/apps/os/backend/durable-objects/organization-websocket.ts
@@ -4,7 +4,7 @@ import type { CloudflareEnv } from "../../env.ts";
 import { getDb } from "../db/client.ts";
 import { getAuth } from "../auth/auth.ts";
 import { getUserEstateAccess } from "../trpc/trpc.ts";
-import { logger as console } from "../tag-logger.ts";
+import { logger } from "../tag-logger.ts";
 
 // Event schemas for WebSocket communication
 export const InvalidateInfo = z.discriminatedUnion("type", [
@@ -135,7 +135,7 @@ export class OrganizationWebSocket extends DurableObject<CloudflareEnv> {
         }),
       );
     } catch (error) {
-      console.error("Error handling message:", error);
+      logger.error("Error handling message:", error);
       ws.send(
         JSON.stringify({
           type: "ERROR",
@@ -168,7 +168,7 @@ export class OrganizationWebSocket extends DurableObject<CloudflareEnv> {
           ws.send(message);
           successCount++;
         } catch (error) {
-          console.error(`Failed to send to session ${ws}:`, error);
+          logger.error(`Failed to send to session ${ws}:`, error);
           errorCount++;
           ws.close();
         }
@@ -186,7 +186,7 @@ export class OrganizationWebSocket extends DurableObject<CloudflareEnv> {
         },
       );
     } catch (error) {
-      console.error("Error handling invalidate:", error);
+      logger.error("Error handling invalidate:", error);
       return new Response(JSON.stringify({ error: "Internal server error" }), {
         status: 500,
         headers: { "Content-Type": "application/json" },
@@ -207,7 +207,7 @@ export class OrganizationWebSocket extends DurableObject<CloudflareEnv> {
           ws.send(message);
           successCount++;
         } catch (error) {
-          console.error(`Failed to send to session ${ws}:`, error);
+          logger.error(`Failed to send to session ${ws}:`, error);
           errorCount++;
           // Remove dead sessions
           ws.close();
@@ -226,7 +226,7 @@ export class OrganizationWebSocket extends DurableObject<CloudflareEnv> {
         },
       );
     } catch (error) {
-      console.error("Error handling broadcast:", error);
+      logger.error("Error handling broadcast:", error);
       return new Response(JSON.stringify({ error: "Internal server error" }), {
         status: 500,
         headers: { "Content-Type": "application/json" },

--- a/apps/os/backend/integrations/github/build-callback.ts
+++ b/apps/os/backend/integrations/github/build-callback.ts
@@ -6,7 +6,7 @@ import type { Variables } from "../../worker";
 import * as schema from "../../db/schema.ts";
 import { verifySignedUrl, BuildCallbackPayload } from "../../utils/url-signing.ts";
 import { invalidateOrganizationQueries } from "../../utils/websocket-utils.ts";
-import { logger as console } from "../../tag-logger.ts";
+import { logger } from "../../tag-logger.ts";
 
 export const buildCallbackApp = new Hono<{ Bindings: CloudflareEnv; Variables: Variables }>();
 
@@ -16,7 +16,7 @@ buildCallbackApp.post("/callback", zValidator("json", BuildCallbackPayload), asy
   const isValid = await verifySignedUrl(url, c.env.EXPIRING_URLS_SIGNING_KEY);
 
   if (!isValid) {
-    console.error("Invalid or expired callback URL");
+    logger.error("Invalid or expired callback URL");
     return c.json({ error: "Invalid or expired callback URL" }, 401);
   }
 
@@ -79,8 +79,8 @@ buildCallbackApp.post("/callback", zValidator("json", BuildCallbackPayload), asy
             },
           });
       } catch (parseError) {
-        console.error("Failed to parse configuration output:", parseError);
-        console.error("Stdout that failed to parse:", stdout);
+        logger.error("Failed to parse configuration output:", parseError);
+        logger.error("Stdout that failed to parse:", stdout);
         // The build succeeded but we couldn't parse the config
         // This is logged but not treated as a build failure
       }

--- a/apps/os/backend/integrations/slack/slack-utils.ts
+++ b/apps/os/backend/integrations/slack/slack-utils.ts
@@ -1,7 +1,7 @@
 import { WebClient } from "@slack/web-api";
 import { getDb } from "../../db/client.ts";
 import { env } from "../../../env.ts";
-import { logger as console } from "../../tag-logger.ts";
+import { logger } from "../../tag-logger.ts";
 import { getSlackAccessTokenForEstate } from "../../auth/token-utils.ts";
 
 /**
@@ -18,7 +18,7 @@ export async function sendNotificationToIterateSlack(
   const notificationEstateId = env.ITERATE_NOTIFICATION_ESTATE_ID;
 
   if (!notificationEstateId) {
-    console.warn("ITERATE_NOTIFICATION_ESTATE_ID not configured, skipping notification");
+    logger.warn("ITERATE_NOTIFICATION_ESTATE_ID not configured, skipping notification");
     return;
   }
 
@@ -28,7 +28,7 @@ export async function sendNotificationToIterateSlack(
   const slackToken = await getSlackAccessTokenForEstate(db, notificationEstateId);
 
   if (!slackToken) {
-    console.error("Slack access token not found for notification estate", {
+    logger.error("Slack access token not found for notification estate", {
       estateId: notificationEstateId,
     });
     return;

--- a/apps/os/backend/sandbox/run-config.ts
+++ b/apps/os/backend/sandbox/run-config.ts
@@ -1,7 +1,7 @@
 import { getSandbox } from "@cloudflare/sandbox";
 import { typeid } from "typeid-js";
 import type { CloudflareEnv } from "../../env.ts";
-import { logger as console } from "../tag-logger.ts";
+import { logger } from "../tag-logger.ts";
 
 export interface RunConfigOptions {
   githubRepoUrl: string;
@@ -41,7 +41,7 @@ export async function runConfigInSandbox(
   try {
     return await runConfigInSandboxInternal(env, options);
   } catch (error) {
-    console.error("Error running config in sandbox:", error);
+    logger.error("Error running config in sandbox:", error);
     return {
       error: "Internal server error during build",
       details: error instanceof Error ? error.message : "Unknown error",

--- a/apps/os/backend/trpc/routers/integrations.ts
+++ b/apps/os/backend/trpc/routers/integrations.ts
@@ -6,7 +6,7 @@ import { WebClient } from "@slack/web-api";
 import { estateProtectedProcedure, router } from "../trpc.ts";
 import { account, organizationUserMembership, estateAccountsPermissions } from "../../db/schema.ts";
 import * as schemas from "../../db/schema.ts";
-import { logger as console } from "../../tag-logger.ts";
+import { logger } from "../../tag-logger.ts";
 import {
   generateGithubJWT,
   getGithubInstallationForEstate,
@@ -270,9 +270,7 @@ export const integrationsRouter = router({
 
       // Safety check to prevent infinite loops (max 10 pages = 1000 repos)
       if (page > 10) {
-        console.warn(
-          `Stopping repository fetch at page ${page - 1} to prevent excessive API calls`,
-        );
+        logger.warn(`Stopping repository fetch at page ${page - 1} to prevent excessive API calls`);
         break;
       }
     }
@@ -310,12 +308,12 @@ export const integrationsRouter = router({
           repoName = repoData.name;
           repoFullName = repoData.full_name;
         } else {
-          console.error(
+          logger.error(
             `Failed to fetch repository details: ${repoResponse.status} ${repoResponse.statusText}`,
           );
         }
       } catch (error) {
-        console.error("Error fetching repository details:", error);
+        logger.error("Error fetching repository details:", error);
       }
     }
 
@@ -397,7 +395,7 @@ export const integrationsRouter = router({
         }
       } catch (error) {
         // Log the error but don't fail the connection
-        console.error("Failed to trigger initial build:", error);
+        logger.error("Failed to trigger initial build:", error);
       }
 
       return {
@@ -496,15 +494,15 @@ export const integrationsRouter = router({
 
                   if (!deleteResponse.ok && deleteResponse.status !== 404) {
                     // Log error but don't fail the disconnection
-                    console.error(
+                    logger.error(
                       `Failed to revoke GitHub installation ${acc.accountId}: ${deleteResponse.status} ${deleteResponse.statusText}`,
                     );
                   } else if (deleteResponse.ok) {
-                    console.log(`Successfully revoked GitHub installation ${acc.accountId}`);
+                    logger.log(`Successfully revoked GitHub installation ${acc.accountId}`);
                   }
                 } catch (error) {
                   // Log error but don't fail the disconnection
-                  console.error(`Error revoking GitHub installation ${acc.accountId}:`, error);
+                  logger.error(`Error revoking GitHub installation ${acc.accountId}:`, error);
                 }
               }
             }
@@ -734,7 +732,7 @@ export const integrationsRouter = router({
         ctx.db,
         estateId,
       ).catch((e) => {
-        console.log(e);
+        logger.log(e);
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message:
@@ -754,7 +752,7 @@ export const integrationsRouter = router({
       );
 
       if (!installationInfoRes.ok) {
-        console.log("Failed to get GitHub installation info", await installationInfoRes.text());
+        logger.log("Failed to get GitHub installation info", await installationInfoRes.text());
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: "Failed to get GitHub installation info",
@@ -791,7 +789,7 @@ export const integrationsRouter = router({
       }
 
       if (!createRepoRes.ok) {
-        console.error(await createRepoRes.text());
+        logger.error(await createRepoRes.text());
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: "Failed to create repository",

--- a/apps/os/backend/trpc/trpc.ts
+++ b/apps/os/backend/trpc/trpc.ts
@@ -4,7 +4,7 @@ import { eq } from "drizzle-orm";
 import { organizationUserMembership } from "../db/schema.ts";
 import type { DB } from "../db/client.ts";
 import { invalidateOrganizationQueries, notifyOrganization } from "../utils/websocket-utils.ts";
-import { logger as console } from "../tag-logger.ts";
+import { logger } from "../tag-logger.ts";
 import type { Context } from "./context.ts";
 
 type StandardSchemaFailureResult = Parameters<typeof prettifyError>[0];
@@ -57,7 +57,7 @@ const t = initTRPC.context<Context>().create({
       };
     }
 
-    console.error(`🚨 tRPC Error on ${opts.path ?? "<no-path>"}:`, {
+    logger.error(`🚨 tRPC Error on ${opts.path ?? "<no-path>"}:`, {
       code: error.code,
       message: formattedError,
       zodFormatted,
@@ -119,7 +119,7 @@ const autoInvalidateMiddleware = t.middleware(async ({ ctx, next, type }) => {
         },
       }).catch((error) => {
         // Log but don't fail the mutation if invalidation fails
-        console.error("Failed to invalidate queries:", error);
+        logger.error("Failed to invalidate queries:", error);
       });
     }
   }
@@ -171,7 +171,7 @@ export async function notifyOrganizationFromContext(
   if (membership?.organizationId) {
     await notifyOrganization(ctx.env, membership.organizationId, type, message, extraArgs).catch(
       (error) => {
-        console.error("Failed to send notification:", error);
+        logger.error("Failed to send notification:", error);
       },
     );
   }

--- a/apps/os/backend/utils/websocket-utils.ts
+++ b/apps/os/backend/utils/websocket-utils.ts
@@ -1,6 +1,6 @@
 import type { CloudflareEnv } from "../../env.ts";
 import type { PushControllerEvent } from "../durable-objects/organization-websocket.ts";
-import { logger as console } from "../tag-logger.ts";
+import { logger } from "../tag-logger.ts";
 
 /**
  * Send an invalidation message to all connected WebSocket clients for an organization
@@ -24,7 +24,7 @@ export async function invalidateOrganizationQueries(
   );
 
   if (!response.ok) {
-    console.error("Failed to send invalidation:", await response.text());
+    logger.error("Failed to send invalidation:", await response.text());
   }
 }
 
@@ -57,7 +57,7 @@ export async function notifyOrganization(
   );
 
   if (!response.ok) {
-    console.error("Failed to send notification:", await response.text());
+    logger.error("Failed to send notification:", await response.text());
   }
 }
 
@@ -86,7 +86,7 @@ export async function broadcastToOrganization(
   );
 
   if (!response.ok) {
-    console.error("Failed to broadcast message:", await response.text());
+    logger.error("Failed to broadcast message:", await response.text());
   }
 }
 
@@ -107,7 +107,7 @@ export async function getOrganizationWebSocketStats(
   );
 
   if (!response.ok) {
-    console.error("Failed to get stats:", await response.text());
+    logger.error("Failed to get stats:", await response.text());
     return null;
   }
 

--- a/apps/os/backend/worker.ts
+++ b/apps/os/backend/worker.ts
@@ -20,7 +20,7 @@ import { OrganizationWebSocket } from "./durable-objects/organization-websocket.
 import { runConfigInSandbox } from "./sandbox/run-config.ts";
 import { githubApp } from "./integrations/github/router.ts";
 import { buildCallbackApp } from "./integrations/github/build-callback.ts";
-import { logger as console } from "./tag-logger.ts";
+import { logger } from "./tag-logger.ts";
 
 declare module "react-router" {
   export interface AppLoadContext {
@@ -44,7 +44,7 @@ app.use(contextStorage());
 // Error tracking with PostHog
 app.onError((err, c) => {
   // Log the error
-  console.error("Unhandled error:", err);
+  logger.error("Unhandled error:", err);
 
   // Track error in PostHog (non-blocking)
   waitUntil(
@@ -105,7 +105,7 @@ app.all("/api/agents/:estateId/:className/:agentInstanceName", async (c) => {
     if (message.includes("not found")) {
       return c.json({ error: "Agent not found" }, 404);
     }
-    console.error("Failed to get agent stub:", error);
+    logger.error("Failed to get agent stub:", error);
     return c.json({ error: "Failed to connect to agent" }, 500);
   }
 });
@@ -119,7 +119,7 @@ app.all("/api/trpc/*", (c) => {
     allowMethodOverride: true,
     createContext: (opts) => createContext(c, opts),
     onError: ({ path, error, type, input }) => {
-      console.error(`❌ tRPC server error on ${path ?? "<no-path>"}:`, {
+      logger.error(`❌ tRPC server error on ${path ?? "<no-path>"}:`, {
         type,
         code: error.code,
         message: error.message,
@@ -237,7 +237,7 @@ app.post(
 
       return c.json(result);
     } catch (error) {
-      console.error("Test build error:", error);
+      logger.error("Test build error:", error);
       return c.json(
         {
           error: "Internal server error during build test",


### PR DESCRIPTION
(no more `import { logger as console }`)

cursor did this

prompt:
>find all the places where we're doing `import { logger as console }` and change to just `import { logger }` then change all the `console.whatever(...)` in affected files to `logger.whatever(...)`

work it did 💀:

https://github.com/user-attachments/assets/8219247d-9c02-47df-8eba-6617c83505fe

