### PR TITLE
fix: add system prompt to observability logs

### DIFF
--- a/apps/os/backend/agent/braintrust-wrapper.ts
+++ b/apps/os/backend/agent/braintrust-wrapper.ts
@@ -1,6 +1,9 @@
 import { startSpan } from "braintrust/browser";
 import type OpenAI from "openai";
-import { formatItemsForObservability } from "../utils/observability-formatter.ts";
+import {
+  formatInputForObservability,
+  formatItemsForObservability,
+} from "../utils/observability-formatter.ts";
 
 export interface OpenAIResponse {
   messages: OpenAI.Responses.ResponseInputItem[];
@@ -28,15 +31,14 @@ export async function logLLMRequestToBraintrust(params: {
     ...(braintrustParentSpanExportedId ? { parent: braintrustParentSpanExportedId } : {}),
   });
 
-  const { input: inputMessages, instructions: _includedAsInputMessage, ...inputMetadata } = input;
+  const {
+    input: _inputMessages,
+    instructions: _includedInFormattedInput,
+    ...inputMetadata
+  } = input;
 
   span.log({
-    input:
-      typeof inputMessages === "string"
-        ? inputMessages
-        : inputMessages
-          ? formatItemsForObservability(inputMessages)
-          : [],
+    input: formatInputForObservability(input),
     output: formatItemsForObservability(response.messages),
     metadata: {
       ...inputMetadata,

--- a/apps/os/backend/agent/posthog-openai-wrapper.ts
+++ b/apps/os/backend/agent/posthog-openai-wrapper.ts
@@ -1,6 +1,6 @@
 import type OpenAI from "openai";
 import { SELF_AGENT_DISTINCT_ID, type PosthogCloudflare } from "../utils/posthog-cloudflare.ts";
-import { formatItemsForObservability } from "../utils/observability-formatter.ts";
+import { formatInputForObservability } from "../utils/observability-formatter.ts";
 import { logger } from "../tag-logger.ts";
 
 // Global trace storage for conversation continuity
@@ -50,12 +50,7 @@ export function posthogOpenAIWrapper(
         $ai_trace_id: traceId,
 
         // input/output data
-        $ai_input:
-          typeof input.input === "string"
-            ? input.input
-            : input.input
-              ? formatItemsForObservability(input.input)
-              : [],
+        $ai_input: formatInputForObservability(input),
         $ai_output_choices: [output],
         $ai_function_calls: output.filter((o) => o.type === "function_call"),
         $ai_tools: input.tools,

--- a/apps/os/backend/utils/observability-formatter.ts
+++ b/apps/os/backend/utils/observability-formatter.ts
@@ -59,6 +59,21 @@ same deal for posthog - although it's not as egregious, it does look nicer when 
 
 import type OpenAI from "openai";
 
+export function formatInputForObservability(input: OpenAI.Responses.ResponseCreateParamsStreaming) {
+  const formattedInput =
+    typeof input.input === "string"
+      ? [{ role: "user", content: input.input, type: "message" }]
+      : input.input
+        ? formatItemsForObservability(input.input)
+        : [];
+
+  const systemPrompt = input.instructions
+    ? [{ role: "system", content: input.instructions, type: "message" }]
+    : [];
+
+  return [...systemPrompt, ...formattedInput];
+}
+
 export function formatItemsForObservability(messages: OpenAI.Responses.ResponseInputItem[]) {
   return messages
     .map((message) => {


### PR DESCRIPTION
[ITE-3079: Add system prompt to posthog traces](https://linear.app/iterate-com/issue/ITE-3079/add-system-prompt-to-posthog-traces)

The same problem was also on braintrust so i just made a shared helper