### PR TITLE
feat: add Sora video generation tool

### DIFF
--- a/apps/os/backend/agent/iterate-agent-tools.ts
+++ b/apps/os/backend/agent/iterate-agent-tools.ts
@@ -159,6 +159,27 @@ export const iterateAgentTools = defineDOTools({
       overrideReplicateParams: z.record(z.string(), z.any()).optional(),
     }),
   },
+  generateVideo: {
+    description:
+      "Generate a video with OpenAI Sora 2. The tool immediately returns the create API response and will share the finished video automatically once it has been uploaded to storage.",
+    input: z.object({
+      prompt: z
+        .string()
+        .describe(
+          "Detailed description of the video you want Sora 2 to create. Include information about setting, camera moves, style, and anything else that matters.",
+        ),
+      additionalParameters: z
+        .record(z.string(), z.any())
+        .default({})
+        .describe(
+          "Optional raw parameters to merge into the Sora 2 request body (e.g. aspect_ratio, duration_seconds). Only include fields explicitly supported by the API.",
+        ),
+      preferredFilename: z
+        .string()
+        .optional()
+        .describe("Optional filename (without extension) to use when saving the generated video."),
+    }),
+  },
   exec: {
     description: "Execute a shell in a sandbox.",
     input: z.object({


### PR DESCRIPTION
## Summary
- add a generateVideo tool definition for IterateAgent that targets OpenAI Sora 2
- implement polling and file sharing workflow for generated videos, including R2 upload and CORE:FILE_SHARED events
- add resilient helpers for parsing create responses, status polling, filename handling, and streaming downloads

## Testing
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_b_68e40c2ed65c8333b7842cc9d3b3a042