### PR TITLE
Automate Slack file sharing for CORE events

### DIFF
--- a/apps/os/backend/agent/default-context-rules.ts
+++ b/apps/os/backend/agent/default-context-rules.ts
@@ -48,15 +48,16 @@ const defaultSlackAgentPrompt = dedent`
 
    ### Calling Tools 
    - You should make use of parallel tool calls as much as possible when calling other tools (in addition to sendSlackMessage). Exception: when a series of actions can only be performed in sequence (ie. you need to get the result of one tool call to be able to call the next tool).
-   - Whenever you call one or more tools, other than sendSlackMessage--> in parallel call sendSlackMessage with a brief description of what you're doing. This must be in italics. 
-   - After each tool call, provide a 1-2 line validation (e.g share links, images, answers, or other relevant output etc.) of the result before proceeding. 
-   - After you've shared the output, validate it and self-correct if needed. 
-   - Otherwise, if you are not making any tool calls / for chat-only interactions --> respond immediately with one concise message and end your turn. 
-    For example, if: 
-     - you don't need to use any tools to help the user(s) achieve their goal, you can just respond directly. 
-     - you do not have access to any tools in your environment that you can use to help the user(s) achieve their goal. 
+   - Whenever you call one or more tools, other than sendSlackMessage--> in parallel call sendSlackMessage with a brief description of what you're doing. This must be in italics.
+   - After each tool call, provide a 1-2 line validation (e.g share links, images, answers, or other relevant output etc.) of the result before proceeding.
+   - After you've shared the output, validate it and self-correct if needed.
+   - Otherwise, if you are not making any tool calls / for chat-only interactions --> respond immediately with one concise message and end your turn.
+    For example, if:
+     - you don't need to use any tools to help the user(s) achieve their goal, you can just respond directly.
+     - you do not have access to any tools in your environment that you can use to help the user(s) achieve their goal.
    - Note: You only have access to the tools available to you in your environment, incl. one tool which allows you to add new tools to your environment: use connectMCPServer given a URL to connect to a remote MCP server (where available) with the required tools.
    - DO NOT hallucinate tools that you don't have access to. Never propose provisioning new infrastructure or integrations, you don't have the capabilities to do that.
+   - When you generate or obtain a file that should be shared back to Slack, you do not need to call a tool. As soon as a CORE:FILE_SHARED event is emitted with direction "from-agent-to-user", the file will automatically be uploaded and shared in the current thread.
 
    Example: tool call in parallel with sendSlackMessage
    First LLM response in agent turn: (parallel tool calls)
@@ -186,7 +187,6 @@ export const defaultContextRules = defineRules([
       slackAgentTool.stopRespondingUntilMentioned(),
       slackAgentTool.addSlackReaction(),
       slackAgentTool.removeSlackReaction(),
-      slackAgentTool.uploadAndShareFileInSlack(),
       slackAgentTool.updateSlackMessage(),
       iterateAgentTool.getURLContent(),
       iterateAgentTool.searchWeb({

--- a/apps/os/backend/agent/slack-agent-tools.ts
+++ b/apps/os/backend/agent/slack-agent-tools.ts
@@ -62,17 +62,6 @@ export const slackAgentTools = defineDOTools({
       name: z.string().describe("The emoji name (without colons, e.g., 'thumbsup')"),
     }),
   },
-  uploadAndShareFileInSlack: {
-    description:
-      "Upload and share a file with all users in the current Slack conversation with rich preview/unfurling",
-    input: z.object({
-      iterateFileId: z.string().describe("The Iterate file ID to upload"),
-      // If you allow the agent to provide a comment with the file, it will say something like "here's your file",
-      // and then again sendSlackMessage({ text: "here's your file", endTurn: true })
-      // TODO: Find a better solution to that prompting issue that doens't take away the ability to provide a comment with the file
-      // initialComment: z.string().optional().describe("Optional comment to include with the file"),
-    }),
-  },
   updateSlackMessage: {
     description:
       "Update a message in a Slack channel. This is useful for updating the content of a message after it has been sent.",

--- a/apps/os/backend/agent/slack-agent.ts
+++ b/apps/os/backend/agent/slack-agent.ts
@@ -796,7 +796,7 @@ export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsI
     } satisfies MagicAgentInstructions;
   }
 
-  private async shareFileWithSlack(params: {
+  async shareFileWithSlack(params: {
     iterateFileId: string;
     originalFilename?: string | null;
   }) {

--- a/apps/os/backend/agent/slack-agent.ts
+++ b/apps/os/backend/agent/slack-agent.ts
@@ -170,6 +170,23 @@ export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsI
               },
             ]);
             break;
+          case "CORE:FILE_SHARED": {
+            const fileSharedEvent = payload.event as AgentCoreEvent & { type: "CORE:FILE_SHARED" };
+            if (fileSharedEvent.data.direction === "from-agent-to-user") {
+              this.ctx.waitUntil(
+                this.shareFileWithSlack({
+                  iterateFileId: fileSharedEvent.data.iterateFileId,
+                  originalFilename: fileSharedEvent.data.originalFilename,
+                }).catch((error) => {
+                  logger.warn(
+                    `[SlackAgent] Failed automatically sharing file ${fileSharedEvent.data.iterateFileId} in Slack:`,
+                    error,
+                  );
+                }),
+              );
+            }
+            break;
+          }
           case "CORE:INTERNAL_ERROR": {
             logger.error("[SlackAgent] Internal Error:", payload.event);
             const errorEvent = payload.event as AgentCoreEvent & { type: "CORE:INTERNAL_ERROR" };
@@ -751,81 +768,6 @@ export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsI
     });
   }
 
-  async uploadAndShareFileInSlack(input: Inputs["uploadAndShareFileInSlack"]) {
-    const slackThreadId = this.agentCore.state.slackThreadId;
-    const slackChannelId = this.agentCore.state.slackChannelId;
-
-    if (typeof slackThreadId !== "string" || typeof slackChannelId !== "string") {
-      throw new Error(
-        "INTERNAL ERROR: Slack thread ID and channel ID are not set on the agent core state. This is an iterate bug.",
-      );
-    }
-    const { content, fileRecord } = await getFileContent({
-      iterateFileId: input.iterateFileId,
-      db: this.db,
-      estateId: this.databaseRecord.estateId,
-    });
-
-    // Ensure filename has a proper extension for better Slack unfurl behavior
-    const filename = fileRecord.filename || fileRecord.id;
-    const filenameWithExtension = filename.includes(".") ? filename : `${filename}.txt`;
-
-    try {
-      // The Slack SDK's uploadV2 helper doesn't handle ReadableStream properly,
-      // so we implement the three-step process manually as per:
-      // https://docs.slack.dev/messaging/working-with-files/#upload
-
-      // Convert ReadableStream to Buffer for upload
-      const buffer = Buffer.from(await new Response(content).arrayBuffer());
-
-      // Step 1: Get upload URL from Slack
-      const uploadUrlResponse = await this.slackAPI.files.getUploadURLExternal({
-        filename: filenameWithExtension,
-        length: buffer.length,
-      });
-
-      if (!uploadUrlResponse.ok || !uploadUrlResponse.upload_url || !uploadUrlResponse.file_id) {
-        throw new Error("Failed to get upload URL from Slack");
-      }
-
-      // Step 2: Upload file data to the external URL
-      // The external URL expects raw binary data, not multipart form data
-      const uploadResponse = await fetch(uploadUrlResponse.upload_url, {
-        method: "POST",
-        body: buffer,
-        headers: {
-          "Content-Type": fileRecord.mimeType || "application/octet-stream",
-          "Content-Length": buffer.length.toString(),
-        },
-      });
-
-      if (!uploadResponse.ok) {
-        throw new Error(`Failed to upload file data: ${uploadResponse.statusText}`);
-      }
-
-      // Step 3: Complete the upload and share in the channel
-      const completeResponse = await this.slackAPI.files.completeUploadExternal({
-        files: [
-          {
-            id: uploadUrlResponse.file_id,
-            title: filenameWithExtension,
-          },
-        ],
-        channel_id: slackChannelId,
-        thread_ts: slackThreadId,
-      });
-
-      return completeResponse;
-    } catch (error) {
-      logger.warn("[SlackAgent] Failed uploading file:", error);
-      logger.log("Full error details:", JSON.stringify(error, null, 2));
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : "Unknown error",
-      };
-    }
-  }
-
   async updateSlackMessage(input: Inputs["updateSlackMessage"]) {
     return await this.slackAPI.chat.update({
       channel: this.agentCore.state.slackChannelId!,
@@ -852,5 +794,69 @@ export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsI
       __pauseAgentUntilMentioned: true,
       __triggerLLMRequest: false,
     } satisfies MagicAgentInstructions;
+  }
+
+  private async shareFileWithSlack(params: {
+    iterateFileId: string;
+    originalFilename?: string | null;
+  }) {
+    const slackThreadId = this.agentCore.state.slackThreadId;
+    const slackChannelId = this.agentCore.state.slackChannelId;
+
+    if (typeof slackThreadId !== "string" || typeof slackChannelId !== "string") {
+      throw new Error(
+        "INTERNAL ERROR: Slack thread ID and channel ID are not set on the agent core state. This is an iterate bug.",
+      );
+    }
+
+    const { content, fileRecord } = await getFileContent({
+      iterateFileId: params.iterateFileId,
+      db: this.db,
+      estateId: this.databaseRecord.estateId,
+    });
+
+    const filename = params.originalFilename || fileRecord.filename || fileRecord.id;
+    const filenameWithExtension = filename.includes(".") ? filename : `${filename}.txt`;
+
+    const buffer = Buffer.from(await new Response(content).arrayBuffer());
+
+    const uploadUrlResponse = await this.slackAPI.files.getUploadURLExternal({
+      filename: filenameWithExtension,
+      length: buffer.length,
+    });
+
+    if (!uploadUrlResponse.ok || !uploadUrlResponse.upload_url || !uploadUrlResponse.file_id) {
+      throw new Error("Failed to get upload URL from Slack");
+    }
+
+    const uploadResponse = await fetch(uploadUrlResponse.upload_url, {
+      method: "POST",
+      body: buffer,
+      headers: {
+        "Content-Type": fileRecord.mimeType || "application/octet-stream",
+        "Content-Length": buffer.length.toString(),
+      },
+    });
+
+    if (!uploadResponse.ok) {
+      throw new Error(`Failed to upload file data: ${uploadResponse.statusText}`);
+    }
+
+    const completeResponse = await this.slackAPI.files.completeUploadExternal({
+      files: [
+        {
+          id: uploadUrlResponse.file_id,
+          title: filenameWithExtension,
+        },
+      ],
+      channel_id: slackChannelId,
+      thread_ts: slackThreadId,
+    });
+
+    if (!completeResponse.ok) {
+      throw new Error(
+        `Failed to share file in Slack: ${completeResponse.error ?? "Unknown error"}`,
+      );
+    }
   }
 }

--- a/apps/os/backend/agent/slack-agent.ts
+++ b/apps/os/backend/agent/slack-agent.ts
@@ -796,10 +796,7 @@ export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsI
     } satisfies MagicAgentInstructions;
   }
 
-  async shareFileWithSlack(params: {
-    iterateFileId: string;
-    originalFilename?: string | null;
-  }) {
+  async shareFileWithSlack(params: { iterateFileId: string; originalFilename?: string | null }) {
     const slackThreadId = this.agentCore.state.slackThreadId;
     const slackChannelId = this.agentCore.state.slackChannelId;
 


### PR DESCRIPTION
## Summary
- automatically upload files to Slack when CORE:FILE_SHARED events are emitted from the agent
- remove the uploadAndShareFileInSlack tool and mention the automatic behavior in Slack agent context rules
- clean up Slack agent tool definitions to reflect the streamlined workflow

## Testing
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_b_68e40d4d10588333b6033ab1d3502a99