### PR TITLE
fix global connection cache

### DIFF
--- a/apps/os/backend/agent/iterate-agent.ts
+++ b/apps/os/backend/agent/iterate-agent.ts
@@ -46,7 +46,12 @@ import {
   type AugmentedCoreReducedState,
 } from "./agent-core-schemas.ts";
 import type { DOToolDefinitions } from "./do-tools.ts";
-import { runMCPEventHooks, getOrCreateMCPConnection } from "./mcp/mcp-event-hooks.ts";
+import {
+  runMCPEventHooks,
+  getOrCreateMCPConnection,
+  createMCPManagerCache,
+  type MCPManagerCache,
+} from "./mcp/mcp-event-hooks.ts";
 import { mcpSlice, getConnectionKey } from "./mcp/mcp-slice.ts";
 import { MCPConnectRequestEventInput } from "./mcp/mcp-slice.ts";
 import { iterateAgentTools } from "./iterate-agent-tools.ts";
@@ -371,6 +376,8 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
   _organization?: typeof schema.organization.$inferSelect;
   _iterateConfig?: IterateConfig;
 
+  protected mcpManagerCache: MCPManagerCache;
+
   // This gets run between the synchronous durable object constructor and the asynchronous onStart method of the agents SDK
   async initAfterConstructorBeforeOnStart(params: AgentInitParams) {
     this._databaseRecord = params.record;
@@ -408,6 +415,8 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
   constructor(ctx: DurableObjectState, env: CloudflareEnv) {
     super(ctx, env);
     this.db = getDb();
+    // Initialize instance-level MCP manager cache
+    this.mcpManagerCache = createMCPManagerCache();
     // DO NOT CHANGE THE SCHEMA WITHOUT UPDATING THE MIGRATION LOGIC
     // If you need to change the schema, you can add more columns with separate statements
     this.sql`
@@ -620,6 +629,7 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
                   reducedState,
                   agentDurableObject: this.hydrationInfo,
                   estateId: this.databaseRecord.estateId,
+                  cache: this.mcpManagerCache,
                   getFinalRedirectUrl: deps.getFinalRedirectUrl!,
                 });
 
@@ -655,6 +665,7 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
         getDurableObjectInfo: () => this.hydrationInfo,
         getEstateId: () => this.databaseRecord.estateId,
         getReducedState: () => this.agentCore.state,
+        cache: this.mcpManagerCache,
         getFinalRedirectUrl: async (payload: { durableObjectInstanceName: string }) => {
           return `${this.env.VITE_PUBLIC_URL}/agents/IterateAgent/${payload.durableObjectInstanceName}`;
         },
@@ -1234,6 +1245,7 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
       agentDurableObject: this.hydrationInfo,
       estateId: this.databaseRecord.estateId,
       reducedState: this.getReducedState(),
+      cache: this.mcpManagerCache,
       getFinalRedirectUrl: this.agentCore.getFinalRedirectUrl.bind(this.agentCore),
     });
 

--- a/apps/os/backend/agent/mcp/mcp-oauth-provider.ts
+++ b/apps/os/backend/agent/mcp/mcp-oauth-provider.ts
@@ -233,6 +233,10 @@ export class MCPOAuthProvider implements AgentsOAuthProvider {
     const state = generateRandomString(32);
     authUrl.searchParams.set("state", state);
 
+    if (!this.serverId) {
+      throw new Error("Server ID must be set before redirecting to authorization");
+    }
+
     const stateData: MCPOAuthState = {
       integrationSlug: this.params.integrationSlug,
       serverUrl: this.params.serverUrl,
@@ -246,6 +250,7 @@ export class MCPOAuthProvider implements AgentsOAuthProvider {
         durableObjectName: this.params.agentDurableObject.durableObjectName,
         className: this.params.agentDurableObject.className,
       },
+      serverId: this.serverId,
     };
 
     const expiresAt = new Date(Date.now() + 10 * 60 * 1000); // 10 minutes for OAuth flow

--- a/apps/os/backend/agent/mcp/mcp-slice.test.ts
+++ b/apps/os/backend/agent/mcp/mcp-slice.test.ts
@@ -196,6 +196,7 @@ describe("mcp-slice", () => {
             userId: "user123",
             integrationSlug: "github",
             oauthUrl: "https://github.com/oauth/authorize",
+            serverId: "server-123",
           },
           metadata: {},
           triggerLLMRequest: false,
@@ -786,13 +787,14 @@ describe("mcp-slice", () => {
             userId: "user123",
             integrationSlug: "github",
             oauthUrl: "https://github.com/oauth/authorize",
+            serverId: "server-123",
           },
         });
 
         const state = h.agentCore.state as any;
         expect(state.mcpConnections).toHaveProperty(connectionKey);
         expect(state.mcpConnections[connectionKey]).toMatchObject({
-          serverId: "",
+          serverId: "server-123",
           serverUrl: "https://github.com/mcp",
           mode: "personal",
           userId: "user123",
@@ -822,6 +824,7 @@ describe("mcp-slice", () => {
             mode: "company" as const,
             integrationSlug: "github",
             oauthUrl: "",
+            serverId: "server-123",
           },
         });
 
@@ -861,6 +864,7 @@ describe("mcp-slice", () => {
             mode: "company" as const,
             integrationSlug: "github",
             oauthUrl: "https://github.com/oauth/authorize",
+            serverId: "server-456",
           },
         });
       });

--- a/apps/os/backend/agent/mcp/mcp-slice.ts
+++ b/apps/os/backend/agent/mcp/mcp-slice.ts
@@ -95,6 +95,7 @@ const mcpConnectRequestFields = {
     requiresParams: z.array(MCPParam).optional(),
     reconnect: z
       .object({
+        id: z.string(),
         oauthClientId: z.string(),
         oauthCode: z.string(),
       })
@@ -206,6 +207,7 @@ const mcpOAuthRequiredFields = {
     userId: z.string().optional(),
     integrationSlug: z.string(),
     oauthUrl: z.string(),
+    serverId: z.string(),
   }),
 };
 
@@ -350,6 +352,8 @@ export interface MCPSliceDeps {
   lazyConnectionDeps?: LazyConnectionDeps;
 }
 
+export type { MCPManagerCache } from "./mcp-event-hooks.ts";
+
 // ------------------------- Slice Definition -------------------------
 
 export const mcpSlice = defineAgentCoreSlice<{
@@ -476,7 +480,8 @@ export const mcpSlice = defineAgentCoreSlice<{
       }
 
       case "MCP:OAUTH_REQUIRED": {
-        const { connectionKey, serverUrl, mode, userId, integrationSlug, oauthUrl } = event.data;
+        const { connectionKey, serverUrl, mode, userId, integrationSlug, oauthUrl, serverId } =
+          event.data;
 
         if (!oauthUrl) {
           return {};
@@ -497,7 +502,7 @@ export const mcpSlice = defineAgentCoreSlice<{
           mcpConnections: {
             ...state.mcpConnections,
             [connectionKey]: {
-              serverId: "",
+              serverId,
               serverUrl,
               mode,
               userId,

--- a/apps/os/backend/agent/mcp/mcp-tool-mapping.test.ts
+++ b/apps/os/backend/agent/mcp/mcp-tool-mapping.test.ts
@@ -693,10 +693,12 @@ describe("mcp-tool-mapping", () => {
     });
 
     let mockCache: MCPManagerCache;
+    let mockConnectionQueues: MCPConnectionQueues;
 
     beforeEach(() => {
       vi.clearAllMocks();
       mockCache = createMCPManagerCache();
+      mockConnectionQueues = createMCPConnectionQueues();
     });
 
     it("should create runtime tool for team connection", async () => {
@@ -786,7 +788,8 @@ describe("mcp-tool-mapping", () => {
         }),
         getEstateId: () => "test-estate-id",
         getReducedState: () => ({ mcpConnections: {} }) as any,
-        cache: mockCache,
+        mcpConnectionCache: mockCache,
+        mcpConnectionQueues: mockConnectionQueues,
       };
 
       const runtimeTool = createRuntimeToolFromMCPTool({

--- a/apps/os/backend/agent/mcp/mcp-tool-mapping.ts
+++ b/apps/os/backend/agent/mcp/mcp-tool-mapping.ts
@@ -11,6 +11,7 @@ import {
   rehydrateExistingMCPConnection,
   createCacheKey,
   type MCPManagerCache,
+  type MCPConnectionQueues,
 } from "./mcp-event-hooks.ts";
 import { MCPConnectionKey, type MCPConnection, type MCPTool } from "./mcp-slice.ts";
 import type { MCPEventHookReturnEvent } from "./mcp-event-hooks.ts";
@@ -343,7 +344,8 @@ export interface LazyConnectionDeps {
   getDurableObjectInfo: () => AgentDurableObjectInfo;
   getEstateId: () => string;
   getReducedState: () => MergedStateForSlices<CoreAgentSlices>;
-  cache: MCPManagerCache;
+  mcpConnectionCache: MCPManagerCache;
+  mcpConnectionQueues: MCPConnectionQueues;
   getFinalRedirectUrl?: (payload: {
     durableObjectInstanceName: string;
   }) => Promise<string | undefined>;
@@ -441,7 +443,7 @@ export function createRuntimeToolFromMCPTool(params: {
       }
 
       const cacheKey = createCacheKey(selectedConnectionKey);
-      let manager = params.lazyConnectionDeps.cache.managers.get(cacheKey);
+      let manager = params.lazyConnectionDeps.mcpConnectionCache.managers.get(cacheKey);
 
       if (!manager) {
         const reducedState = params.lazyConnectionDeps.getReducedState();
@@ -461,7 +463,8 @@ export function createRuntimeToolFromMCPTool(params: {
           agentDurableObject: params.lazyConnectionDeps.getDurableObjectInfo(),
           estateId: params.lazyConnectionDeps.getEstateId(),
           reducedState: reducedState,
-          cache: params.lazyConnectionDeps.cache,
+          mcpConnectionCache: params.lazyConnectionDeps.mcpConnectionCache,
+          mcpConnectionQueues: params.lazyConnectionDeps.mcpConnectionQueues,
           getFinalRedirectUrl: params.lazyConnectionDeps.getFinalRedirectUrl,
         });
 

--- a/apps/os/backend/agent/slack-agent.ts
+++ b/apps/os/backend/agent/slack-agent.ts
@@ -213,6 +213,7 @@ export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsI
         getDurableObjectInfo: () => this.hydrationInfo,
         getEstateId: () => this.databaseRecord.estateId,
         getReducedState: () => this.agentCore.state,
+        cache: this.mcpManagerCache,
         getFinalRedirectUrl: async (_payload: { durableObjectInstanceName: string }) => {
           return await this.getSlackPermalink();
         },

--- a/apps/os/backend/agent/slack-agent.ts
+++ b/apps/os/backend/agent/slack-agent.ts
@@ -213,7 +213,8 @@ export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsI
         getDurableObjectInfo: () => this.hydrationInfo,
         getEstateId: () => this.databaseRecord.estateId,
         getReducedState: () => this.agentCore.state,
-        cache: this.mcpManagerCache,
+        mcpConnectionCache: this.mcpManagerCache,
+        mcpConnectionQueues: this.mcpConnectionQueues,
         getFinalRedirectUrl: async (_payload: { durableObjectInstanceName: string }) => {
           return await this.getSlackPermalink();
         },

--- a/apps/os/backend/auth/integrations.ts
+++ b/apps/os/backend/auth/integrations.ts
@@ -153,6 +153,7 @@ export const integrationsPlugin = () =>
                   userId: state.userId,
                   integrationSlug: state.integrationSlug,
                   reconnect: {
+                    id: state.serverId,
                     oauthClientId: state.clientId,
                     oauthCode: code,
                   },

--- a/apps/os/backend/auth/oauth-state-schemas.ts
+++ b/apps/os/backend/auth/oauth-state-schemas.ts
@@ -26,6 +26,7 @@ export const MCPOAuthState = BaseOAuthState.extend({
   clientId: z.string(),
   fullUrl: z.string(),
   agentDurableObject: AgentDurableObjectInfo,
+  serverId: z.string(),
 });
 
 export const SlackDirectLoginState = BaseOAuthState.extend({});


### PR DESCRIPTION
Fixes [ITE-3115: Fix the module-level connection cache](https://linear.app/iterate-com/issue/ITE-3115/fix-the-module-level-connection-cache)

Fixes a critical Cloudflare Workers error where MCP manager I/O objects (streams, connections) were being shared across Durable Object boundaries, causing `"Cannot perform I/O on behalf of a different Durable Object"` errors. Additionally fixes MCP OAuth reconnection to use the correct server ID.

## Problem

When MCP tools executed tool calls to MCP server, ReadableStreams and other I/O objects created in one Durable Object context were being accessed from another DO's context. This violates Cloudflare Workers' isolation model, which requires I/O objects to remain within their originating execution context for performance and correctness.

The root cause was a module-level `mcpManagerCache` shared across all DO instances in the same isolate. When DO-A cached a manager with I/O objects, DO-B would retrieve and attempt to use those objects, triggering the error.

Additionally, the MCP OAuth reconnection flow was using a hardcoded placeholder `"cloudflare-requires-id"` instead of the actual server ID from the initial connection attempt, preventing proper reconnection after OAuth authorization.

## Changes

### Instance-Level Cache Architecture
- Created `MCPManagerCache` interface with factory function `createMCPManagerCache()`
- Added `mcpManagerCache` instance property to `IterateAgent` and `SlackAgent`
- Updated all MCP functions (`handleMCPConnectRequest`, `handleMCPDisconnectRequest`, `getOrCreateMCPConnection`, `rehydrateExistingMCPConnection`) to accept cache as a parameter
- Updated `LazyConnectionDeps` interface to include `cache` property for tool execution
- Simplified cache key from `durableObjectId--connectionKey` to just `connectionKey` since each DO now has its own cache

**Result**: Each Durable Object maintains its own isolated cache of MCP managers with I/O objects bound to its execution context, eliminating cross-boundary access.

### OAuth Server ID Preservation
- Added `serverId` field to `MCPOAuthState` schema
- Added `serverId` property to `MCPOAuthProvider` class, set after `manager.connect()` returns
- Updated `MCP:OAUTH_REQUIRED` event to include `serverId`
- Updated `reconnect` parameter schema to include `id` field
- Modified OAuth callback to extract and use `state.serverId` for reconnection
- Updated MCP slice reducer to store actual `serverId` instead of empty string

**Result**: OAuth reconnection now uses the correct server ID from the initial connection attempt, enabling proper session resumption.