### PR TITLE
Create eslint rule for storage access

### DIFF
--- a/apps/os/backend/agent/no-ctx-storage-get-put.rule.test.ts
+++ b/apps/os/backend/agent/no-ctx-storage-get-put.rule.test.ts
@@ -7,7 +7,9 @@ async function runEslintOn(code: string) {
     overrideConfigFile: "/workspace/eslint.config.js",
     fix: false,
   } as any);
-  const results = await eslint.lintText(code, { filePath: "/workspace/apps/os/backend/agent/dummy.ts" });
+  const results = await eslint.lintText(code, {
+    filePath: "/workspace/apps/os/backend/agent/dummy.ts",
+  });
   return results[0];
 }
 
@@ -56,4 +58,3 @@ describe("iterate/no-ctx-storage-get-put", () => {
     expect(messages.length).toBe(0);
   });
 });
-

--- a/apps/os/backend/agent/no-ctx-storage-get-put.rule.test.ts
+++ b/apps/os/backend/agent/no-ctx-storage-get-put.rule.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { ESLint } from "eslint";
+
+async function runEslintOn(code: string) {
+  const eslint = new ESLint({
+    useFlatConfig: true,
+    overrideConfigFile: "/workspace/eslint.config.js",
+    fix: false,
+  } as any);
+  const results = await eslint.lintText(code, { filePath: "/workspace/apps/os/backend/agent/dummy.ts" });
+  return results[0];
+}
+
+describe("iterate/no-ctx-storage-get-put", () => {
+  it("reports this.ctx.storage.get and suggests .storage.kv.get", async () => {
+    const code = `
+      class X {
+        async f() {
+          const result = await this.ctx.storage.get("key");
+          return result;
+        }
+      }
+    `;
+    const res = await runEslintOn(code);
+    const messages = res.messages.filter((m) => m.ruleId?.includes("no-ctx-storage-get-put"));
+    expect(messages.length).toBe(1);
+    expect(messages[0].message).toContain("storage.kv");
+  });
+
+  it("reports this.ctx.storage.put and suggests .storage.kv.put", async () => {
+    const code = `
+      class X {
+        async f() {
+          await this.ctx.storage.put("key", "value");
+        }
+      }
+    `;
+    const res = await runEslintOn(code);
+    const messages = res.messages.filter((m) => m.ruleId?.includes("no-ctx-storage-get-put"));
+    expect(messages.length).toBe(1);
+    expect(messages[0].message).toContain("storage.kv");
+  });
+
+  it("does not report when using storage.kv.get/put", async () => {
+    const code = `
+      class X {
+        async f() {
+          const result = await this.ctx.storage.kv.get("key");
+          await this.ctx.storage.kv.put("key", "value");
+          return result;
+        }
+      }
+    `;
+    const res = await runEslintOn(code);
+    const messages = res.messages.filter((m) => m.ruleId?.includes("no-ctx-storage-get-put"));
+    expect(messages.length).toBe(0);
+  });
+});
+

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -266,7 +266,10 @@ export default defineConfig([
                     node: callee.property,
                     message:
                       "Use this.ctx.storage.kv.{{method}} instead of this.ctx.storage.{{method}} in Durable Objects",
-                    data: { method: callee.property.type === "Identifier" ? callee.property.name : "get/put" },
+                    data: {
+                      method:
+                        callee.property.type === "Identifier" ? callee.property.name : "get/put",
+                    },
                     suggest: [
                       {
                         desc: "Change to .storage.kv.<method>",


### PR DESCRIPTION
Add an ESLint rule `iterate/no-ctx-storage-get-put` to enforce the use of `this.ctx.storage.kv.get/put` over `this.ctx.storage.get/put` in Durable Objects.

---
Linear Issue: [ITE-3134](https://linear.app/iterate-com/issue/ITE-3134/make-an-eslint-rule-w-tests-that-outlaws-the-use-of-async-storageget)

<a href="https://cursor.com/background-agent?bcId=bc-4a1d5b55-c87f-4353-8967-cc0e6ecdda6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4a1d5b55-c87f-4353-8967-cc0e6ecdda6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

